### PR TITLE
Fix pipedald port parameter

### DIFF
--- a/src/PiPedalConfiguration.hpp
+++ b/src/PiPedalConfiguration.hpp
@@ -75,7 +75,15 @@ public:
 
     void SetSocketServerEndpoint(const std::string &endpoint)
     {
-        this->socketServerAddress_ = endpoint;
+        if (endpoint.find(':') == std::string::npos)
+        {
+            // Only a port number was provided, use default address.
+            this->socketServerAddress_ = "0.0.0.0:" + endpoint;
+        }
+        else
+        {
+            this->socketServerAddress_ = endpoint;
+        }
     }
 
     bool GetAccessPointGateway(boost::asio::ip::network_v4 *pGatewayNetwork) const {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -203,7 +203,7 @@ int main(int argc, char *argv[])
         }
         if (parser.Arguments().size() == 0)
         {
-            throw PiPedalException("<config_root> not provided.");
+            throw PiPedalException("<doc_root> not provided.");
         }
         if (help || parser.Arguments().size() == 0)
         {
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
                   << "Options:\n"
                   << "   -systemd: Log to systemd journals instead of to the console.\n"
                   << "   -port: Port to listen on e.g. 80, or 0.0.0.0:80\n"
-                  << "   -log-level: (debug|info|warning|error)"
+                  << "   -log-level: (debug|info|warning|error)\n"
                   << "Example:\n"
                   << "    pipedald /etc/pipedal/config /etc/pipedal/react -port 80 \n"
                      "\n"


### PR DESCRIPTION
The -port parameter in pipedald was only accepting `<ip>:<port>`, not just `<port>`