### PR TITLE
More Arch fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,23 @@ install (
 install (
     DIRECTORY ${VITE_BUILD_DIRECTORY} DESTINATION /etc/pipedal/react
 )
-install (FILES ${PROJECT_SOURCE_DIR}/build/src/notices.txt
-    DESTINATION /etc/pipedal/react/var/)
+if(NOT PIPEDAL_DISABLE_COPYRIGHT_BUILD)
+    install (FILES ${PROJECT_SOURCE_DIR}/build/src/notices.txt
+        DESTINATION /etc/pipedal/react/var/)
+endif()
+
+# Install SQLiteCpp and libzip shared libraries (their own install targets are disabled)
+install (
+    FILES
+        ${PROJECT_BINARY_DIR}/modules/SQLiteCpp/libSQLiteCpp.so.0
+        ${PROJECT_BINARY_DIR}/modules/SQLiteCpp/sqlite3/libsqlite3.so
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+install (
+    FILES
+        ${PROJECT_BINARY_DIR}/modules/libzip/lib/libzip.so.5
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
 
 install (
     DIRECTORY ${PROJECT_SOURCE_DIR}/src/templates 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,7 +79,8 @@ if(NOT PIPEDAL_DISABLE_COPYRIGHT_BUILD)
         DESTINATION /etc/pipedal/react/var/)
 endif()
 
-# Install SQLiteCpp and libzip shared libraries (their own install targets are disabled)
+# Install shared libraries from submodules and FetchContent dependencies
+# whose own install targets are disabled (SQLITECPP_INSTALL=OFF, LIBZIP_DO_INSTALL=OFF)
 install (
     FILES
         ${PROJECT_BINARY_DIR}/modules/SQLiteCpp/libSQLiteCpp.so.0
@@ -89,6 +90,13 @@ install (
 install (
     FILES
         ${PROJECT_BINARY_DIR}/modules/libzip/lib/libzip.so.5
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+install (
+    FILES
+        ${PROJECT_BINARY_DIR}/_deps/ftxui-build/libftxui-component.so.5.0.0
+        ${PROJECT_BINARY_DIR}/_deps/ftxui-build/libftxui-dom.so.5.0.0
+        ${PROJECT_BINARY_DIR}/_deps/ftxui-build/libftxui-screen.so.5.0.0
     DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
 )
 

--- a/docs/BuildPrerequisites.md
+++ b/docs/BuildPrerequisites.md
@@ -44,7 +44,7 @@ Note: in Arch, tests and copyright notices won't work, so they need to be disabl
 {
     "cmake.configureSettings": {                                                                                                                                                                                                         
         "PIPEDAL_EXCLUDE_TESTS": "ON",                                                                                                                                                                                                   
-        "DISABLE_COPYRIGHT_BUILD": "ON"                                                                                                                                                                                                  
+        "PIPEDAL_DISABLE_COPYRIGHT_BUILD": "ON"                                                                                                                                                                                                  
     },
     ...
 }

--- a/docs/BuildPrerequisites.md
+++ b/docs/BuildPrerequisites.md
@@ -38,12 +38,11 @@ Arch:
     There is one AUR package:
     sudo paru -S authbind
 
-Note: in Arch, tests and copyright notices won't work, so they need to be disabled with cmake arguments. Add this to your .vscode/settings.json file:
+Note: in Arch, copyright notices generation won't work, so it needs to be disabled with a cmake argument. Add this to your .vscode/settings.json file:
 
 ```json
 {
-    "cmake.configureSettings": {                                                                                                                                                                                                         
-        "PIPEDAL_EXCLUDE_TESTS": "ON",                                                                                                                                                                                                   
+    "cmake.configureSettings": {                                                                                                                                                                                                        
         "PIPEDAL_DISABLE_COPYRIGHT_BUILD": "ON"                                                                                                                                                                                                  
     },
     ...

--- a/src/AlsaDriverTest.cpp
+++ b/src/AlsaDriverTest.cpp
@@ -28,6 +28,7 @@
 #include <mutex>
 #include <iostream>
 #include <algorithm>
+#include <unistd.h>
 
 #include "AlsaDriver.hpp"
 #include "ChannelRouterSettings.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,32 @@ set(CXX_STANDARD 20)
 
 find_package(PkgConfig REQUIRED)
 
+find_package(Catch2 QUIET)
+
+# Catch2 v3 (Arch, newer distros) uses multi-headers under <catch2/>.
+# Catch2 v2 (Debian/Ubuntu) provides a single catch.hpp at system level.
+# When Catch2 v3 is found via CMake, generate compatibility wrappers so
+# old-style #include "catch.hpp" and #include <catch/catch.hpp> still work.
+if(Catch2_FOUND)
+    # Generate catch.hpp wrapper in the build directory.
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/catch.hpp"
+        "#pragma once\n"
+        "#include <catch2/catch_all.hpp>\n"
+    )
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/catch")
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/catch/catch.hpp"
+        "#pragma once\n"
+        "#include <catch2/catch_all.hpp>\n"
+    )
+    # Add the build directory to the global include paths so that
+    # both #include "catch.hpp" (quote) and #include <catch/catch.hpp> (angle)
+    # can find the compatibility wrappers.
+    include_directories(${CMAKE_CURRENT_BINARY_DIR})
+    message(STATUS "Catch2 v3 found. Generated compatibility wrappers in ${CMAKE_CURRENT_BINARY_DIR}")
+else()
+    message(STATUS "Catch2 CMake package not found. Expecting system catch.hpp (Catch2 v2 style).")
+endif()
+
 pkg_check_modules(PipeWire REQUIRED libpipewire-0.3)
 
 include(FetchContent)
@@ -472,6 +498,10 @@ add_executable(pipedaltest
 target_link_libraries(pipedaltest PRIVATE ${PIPEDAL_LIBS} ${ICU_LIBRARIES})
 target_include_directories(pipedaltest PRIVATE ${PIPEDAL_INCLUDES})
 
+if(Catch2_FOUND)
+    target_link_libraries(pipedaltest PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+endif()
+
 set_target_properties(pipedaltest PROPERTIES EXCLUDE_FROM_ALL ${PIPEDAL_EXCLUDE_TESTS})
 
 if (NOT GITHUB_ACTIONS) # Google perftools are not available on Github action servers.
@@ -501,6 +531,10 @@ add_executable(jsonTest
 )
 target_link_libraries(jsonTest PRIVATE PiPedalCommon)
 target_include_directories(jsonTest PRIVATE ${PIPEDAL_INCLUDES})
+
+if(Catch2_FOUND)
+    target_link_libraries(jsonTest PRIVATE Catch2::Catch2 Catch2::Catch2WithMain)
+endif()
 
 set_target_properties(jsonTest PROPERTIES EXCLUDE_FROM_ALL ${PIPEDAL_EXCLUDE_TESTS})
 

--- a/src/ConfigMain.cpp
+++ b/src/ConfigMain.cpp
@@ -1154,6 +1154,7 @@ void Install(const fs::path &programPrefix, const std::string endpointAddress)
         // Add to audio groups.
         sysExec(USERMOD_BIN " -a -G  " AUDIO_SERVICE_GROUP_NAME " " SERVICE_ACCOUNT_NAME);
         // add to netdev group
+        sysExec(GROUPADD_BIN " -f " NETDEV_GROUP_NAME);
         sysExec(USERMOD_BIN " -a -G  " NETDEV_GROUP_NAME " " SERVICE_ACCOUNT_NAME);
 
         try


### PR DESCRIPTION
Added netdev creation command following your suggestions. Fixes some more issues I've found in Arch when installing. Also fixed pipedal_kconfig for Arch. However I have a different bootloader than the only supported one, GRUB, so it can't enable real time audio. I will try modifying it manually.