### PR TITLE
ALSA: restart the capture stream after an output underrun

### DIFF
--- a/src/AlsaDriver.cpp
+++ b/src/AlsaDriver.cpp
@@ -1525,6 +1525,65 @@ namespace pipedal
             }
             validate_capture_handle();
         }
+        // Bring both streams back from an xrun and start them together again.
+        //
+        // Both recovery paths need exactly this sequence. It used to be spelled
+        // out only in the input path, and the output path had its own shorter
+        // version that prepared playback, drained capture and started neither —
+        // which left capture stopped for good. That failure is invisible from
+        // inside the driver: no error is returned and no xrun is reported, the
+        // capture stream simply stops delivering while playback carries on, so
+        // the symptom is silence at the interface with the plugin chain still
+        // apparently running. Sharing one implementation is what stops the two
+        // from drifting apart again.
+        void resync_streams(snd_pcm_t *capture_handle, snd_pcm_t *playback_handle,
+                            const char *direction)
+        {
+            int err;
+
+            // Worth a line in the log. An xrun that recovers cleanly is
+            // unremarkable, but one that does not leaves the interface silent
+            // with no other trace, and without this there is nothing to tell
+            // the two apart after the fact.
+            Lv2Log::info(SS("Recovering from ALSA " << direction << " underrun."));
+
+            // Unlink first. While the streams are linked, prepare and start
+            // propagate across the whole group, so recovering them one at a
+            // time requires them apart.
+            const bool relink = !capture_and_playback_not_synced;
+            if (relink)
+            {
+                snd_pcm_unlink(capture_handle);
+            }
+
+            if ((err = snd_pcm_prepare(playback_handle)) < 0)
+            {
+                throw std::runtime_error(SS("Cannot prepare playback stream: " << snd_strerror(err)));
+            }
+            if ((err = snd_pcm_prepare(capture_handle)) < 0)
+            {
+                throw std::runtime_error(SS("Cannot prepare capture stream: " << snd_strerror(err)));
+            }
+
+            if (relink)
+            {
+                if ((err = snd_pcm_link(capture_handle, playback_handle)) < 0)
+                {
+                    throw std::runtime_error(SS("Cannot relink streams: " << snd_strerror(err)));
+                }
+            }
+
+            // Same order the audio thread uses for the very first start: fill
+            // the playback buffer, then start capture explicitly. Playback
+            // starts itself once its start threshold is reached, but capture
+            // never does — without this call it sits in PREPARED forever.
+            FillOutputBuffer();
+            if ((err = snd_pcm_start(capture_handle)) < 0)
+            {
+                throw std::runtime_error(SS("Cannot restart capture stream: " << snd_strerror(err)));
+            }
+        }
+
         void recover_from_output_underrun(snd_pcm_t *capture_handle, snd_pcm_t *playback_handle, int err, size_t framesRead)
         {
             validate_capture_handle();
@@ -1534,14 +1593,7 @@ namespace pipedal
                 TraceBufferPositions(framesRead, 'w');
                 if (err == -EPIPE)
                 {
-                    err = snd_pcm_prepare(playback_handle);
-                    if (err < 0)
-                    {
-                        Lv2Log::error(SS("Can't recover from ALSA output underrun. (" << snd_strerror(err) << ")"));
-                        throw PiPedalStateException(SS("Can't recover from ALSA output underrun. (" << snd_strerror(err) << ")"));
-                    }
-                    snd_pcm_drain(capture_handle);
-                    FillOutputBuffer();
+                    resync_streams(capture_handle, playback_handle, "output");
                     TraceBufferPositions(framesRead, 'x');
                 }
                 else
@@ -1567,33 +1619,7 @@ namespace pipedal
                 TraceBufferPositions(bufferedFrames, 'r');
                 if (err == -EPIPE)
                 {
-
-                    // Unlink the streams before recovery
-                    snd_pcm_unlink(capture_handle);
-
-                    // Prepare both streams
-                    if ((err = snd_pcm_prepare(playback_handle)) < 0)
-                    {
-                        throw std::runtime_error(SS("Cannot prepare playback stream: " << snd_strerror(err)));
-                    }
-                    if ((err = snd_pcm_prepare(capture_handle)) < 0)
-                    {
-                        throw std::runtime_error(SS("Cannot prepare capture stream: " << snd_strerror(err)));
-                    }
-
-                    // Resynchronize the streams
-                    if ((err = snd_pcm_link(capture_handle, playback_handle)) < 0)
-                    {
-                        throw std::runtime_error(SS("Cannot relink streams: " << snd_strerror(err)));
-                    }
-
-                    // Start the streams
-                    FillOutputBuffer();
-                    if ((err = snd_pcm_start(capture_handle)) < 0)
-                    {
-                        throw std::runtime_error(SS("Cannot restart capture stream: " << snd_strerror(err)));
-                    }
-
+                    resync_streams(capture_handle, playback_handle, "input");
                     validate_capture_handle();
                 }
                 else if (err == ESTRPIPE)


### PR DESCRIPTION
# ALSA: restart the capture stream after an output underrun

## The symptom

Audio stops coming out of the interface, but PiPedal carries on as though
nothing has happened — the plugin chain still runs, the meters still move, no
error appears in the log, and the underrun counter stops advancing. Going into
Audio Settings and straight back out fixes it every time, because that forces a
full `RestartAudio()`.

I had put this down to my own hardware for a while. It is reproducible on a
Pi 4 with a Universal Audio Volt 476 at both 44.1 and 48 kHz, and it tends to
follow anything that briefly stalls the audio thread — in my case loading a
neural amp model, or changing a model parameter that rebuilds its network.

## The cause

`recover_from_output_underrun()` prepares the playback stream, drains capture,
and starts neither:

```cpp
err = snd_pcm_prepare(playback_handle);
...
snd_pcm_drain(capture_handle);
FillOutputBuffer();
```

Playback comes back on its own, because `FillOutputBuffer()` pushes it past its
start threshold. Capture does not: a capture stream never auto-starts, it has
to be started explicitly. So it is left sitting in `PREPARED` while playback
runs on, and from inside the driver everything looks fine — `snd_pcm_readi()`
is simply never going to return anything again, and no error is raised to say
so.

Caught in the act in `/proc/asound`, at the moment the sound stopped:

```
20:45:55  playback=state: RUNNING  capture=state: SETUP
```

`recover_from_input_underrun()` already handles this correctly, a few lines
below: unlink, prepare both, relink, fill, then `snd_pcm_start(capture)`. The
two paths had simply drifted.

## The change

Both paths now call a single `resync_streams()` helper holding the sequence the
input path already used, so they cannot drift again. Two things came along with
it:

- The unlink/relink is skipped when `capture_and_playback_not_synced` is set,
  i.e. when the two streams could not be linked when the device was opened.
  Previously recovery would throw on the relink and fall through to
  `RestartAlsa()` on every xrun on such a device.
- A log line when recovery runs. This failure mode is invisible precisely
  because nothing is recorded anywhere; an xrun that recovers is unremarkable,
  but one that does not should leave a trace. Happy to drop this or move it to
  `debug` if you would rather keep the log quiet.

Net effect is 61 insertions, 35 deletions, all inside the two recovery
functions.

## Testing

On a Pi 4 (Bookworm, 8 GB) with a Volt 476 at 48 kHz, 128 × 4:

- **Forced input xruns** — `SIGSTOP` the process for 0.4 s, 1.0 s and 2.0 s,
  then `SIGCONT`. Both streams return to `RUNNING` in every case, and the
  capture `hw_ptr` advances 96438 frames over 2 s at 48 kHz, so capture is
  genuinely streaming again rather than merely reporting `RUNNING`.
- **Output xruns** occurred on their own under load during the same session and
  went through the new path twice, both times leaving the streams healthy.
- Several hours of ordinary playing since, with no recurrence of the dropout
  that prompted this.

I could not find a way to provoke an output underrun deterministically without
patching in a fault, so that side is verified by observing real ones rather
than by a controlled trigger. The new code is a strict superset of what the old
output path did, though: everything it used to do, plus preparing and actually
starting capture.

## Note

Found while building a plugin against PiPedal, not while looking for driver
bugs — so please treat the diagnosis as a report from the field rather than a
confident claim about ALSA internals on hardware I do not have. Happy to
rework, split, or drop any part of this.
