### PR TITLE
Disable the automatic stereo-forcing heuristic for multichannel ALSA ...

### DIFF
--- a/src/AlsaDriver.cpp
+++ b/src/AlsaDriver.cpp
@@ -78,6 +78,7 @@ namespace pipedal
 
         if (channelsMax <= 2)
             return false;
+        return false; // Local multichannel-interface fix: do not collapse ALSA devices to stereo based on channel maps.
         if (channelsMin == channelsMax)
             return false;
         if (channelsMin > 2)


### PR DESCRIPTION
Extracted from the `diamondsea11/pipedal` fork as one self-contained change, per your request in #555 to review fork work one topic at a time rather than as a single large diff.

## What this does

`ShouldForceStereoChannels()` inspects a device's ALSA channel map and collapses it to stereo when the map looks like a legacy or surround configuration. On genuinely multichannel interfaces (more than 2 real channels, not a legacy driver reporting a bogus count) that heuristic misfires and forces the device down to 2 channels it does not need collapsing to.

This adds an unconditional early return for `channelsMax > 2`, disabling the heuristic rather than trying to refine it.

**Diff is one line.** The original channel-map logic is deliberately left in place below the new return, not deleted, so the conditions it was trying to detect stay visible for whoever decides its long-term fate. The `channelsMax <= 2` fast path above is untouched.

Your own comment on that function already reads:

> This is high-risk code, because it attempts to anticipate hypothetical device configurations with no actual testing.

so this may be a change you'd rather make differently — happy to follow your lead on that.

## Test status

There is no isolated unit test for this function, and I have not added one. Writing a meaningful test needs either real device channel-map fixtures or refactoring the function to accept mock channel-map data instead of live `snd_pcm_t`/`hw_params` handles. Flagging that rather than implying coverage that doesn't exist.

Verified in practice only on the hardware I have here (RME Babyface Pro FS, 4 in / 4 out), where the heuristic was the thing preventing all four channels from being available.

## Provenance

As discussed in #555: I'm not a developer, and this code is AI-implemented from my descriptions. Please review it as such. I've kept the change as small as I could specifically so that reviewing it is cheap.

Targeting `main` since that's what the branch is based on — happy to retarget to `dev` if you'd prefer.
