### PR TITLE
Fix S24_LE/S24_BE full-scale constant (playback distortion, capture 6 dB low)

### DIFF
--- a/src/AlsaDriver.cpp
+++ b/src/AlsaDriver.cpp
@@ -875,7 +875,10 @@ namespace pipedal
 
             std::vector<float *> &buffers = this->deviceCaptureBuffers;
             int channels = this->captureChannels;
-            constexpr float scale = 1.0f / (0x00FFFFFFL + 1L);
+            // Signed 24-bit full-scale is 0x7FFFFF (2^23-1), not 0x00FFFFFF.
+            // Using 2^24 here decoded full-scale input to only 0.5, i.e. 6 dB
+            // low, matching S16/S32/S24_3 (which all map full-scale to 1.0).
+            constexpr float scale = 1.0f / (0x7FFFFFL + 1L);
             for (size_t frame = 0; frame < frames; ++frame)
             {
                 for (int channel = 0; channel < channels; ++channel)
@@ -891,7 +894,10 @@ namespace pipedal
 
             std::vector<float *> &buffers = this->deviceCaptureBuffers;
             int channels = this->captureChannels;
-            constexpr float scale = 1.0f / (0x00FFFFFFL + 1L);
+            // Signed 24-bit full-scale is 0x7FFFFF (2^23-1), not 0x00FFFFFF.
+            // Using 2^24 here decoded full-scale input to only 0.5, i.e. 6 dB
+            // low, matching S16/S32/S24_3 (which all map full-scale to 1.0).
+            constexpr float scale = 1.0f / (0x7FFFFFL + 1L);
             for (size_t frame = 0; frame < frames; ++frame)
             {
                 for (int channel = 0; channel < channels; ++channel)
@@ -985,7 +991,13 @@ namespace pipedal
 
             std::vector<float *> &buffers = this->devicePlaybackBuffers;
             int channels = this->playbackChannels;
-            constexpr double scale = 0x00FFFFFF;
+            // Signed 24-bit full-scale is 0x7FFFFF (2^23-1). The old value of
+            // 0x00FFFFFF mapped any float above 0.5 (-6 dBFS) to 0x800000.., i.e.
+            // past the signed-24-bit range, so the low 24 bits wrapped to the
+            // opposite polarity -> harsh high-frequency distortion proportional
+            // to signal level (no xruns, normal CPU). The clamp above now limits
+            // correctly to full-scale.
+            constexpr double scale = 0x7FFFFF;
             for (size_t frame = 0; frame < frames; ++frame)
             {
                 for (int channel = 0; channel < channels; ++channel)
@@ -1007,7 +1019,13 @@ namespace pipedal
 
             std::vector<float *> &buffers = this->devicePlaybackBuffers;
             int channels = this->playbackChannels;
-            constexpr double scale = 0x00FFFFFF;
+            // Signed 24-bit full-scale is 0x7FFFFF (2^23-1). The old value of
+            // 0x00FFFFFF mapped any float above 0.5 (-6 dBFS) to 0x800000.., i.e.
+            // past the signed-24-bit range, so the low 24 bits wrapped to the
+            // opposite polarity -> harsh high-frequency distortion proportional
+            // to signal level (no xruns, normal CPU). The clamp above now limits
+            // correctly to full-scale.
+            constexpr double scale = 0x7FFFFF;
             for (size_t frame = 0; frame < frames; ++frame)
             {
                 for (int channel = 0; channel < channels; ++channel)


### PR DESCRIPTION
You asked in #555: *"S24_LE capture/playback scaling. If it's broken, I definitely need a fix for this please."*

It is broken, and the playback side is worse than a level error.

## Root cause

Both directions used `0x00FFFFFF` (2^24 − 1) as the signed 24-bit full-scale reference. The correct value is `0x7FFFFF` (2^23 − 1) — `0x00FFFFFF` is the range of an *unsigned* 24-bit sample, not a signed one.

**Capture:** every sample decoded to half its true level (−6 dBFS). The input just sounds quiet.

**Playback:** any float above 0.5 — already past −6 dBFS, so reachable by perfectly ordinary signal levels — multiplied past the valid signed-24-bit range and wrapped to the opposite polarity in the low 24 bits. The result is harsh, signal-level-proportional high-frequency distortion, with no xruns and normal CPU load, which makes it an unpleasant one to track down by ear.

The existing clamp to `[-1, 1]` was already there and already correct. It simply could not help while the scale constant put post-clamp full-scale outside the representable range.

## Scope

Four functions: `CopyCaptureS24Le`, `CopyCaptureS24Be`, `CopyPlaybackS24Le`, `CopyPlaybackS24Be` — i.e. only the `SND_PCM_FORMAT_S24_LE` / `S24_BE` paths, where 24 bits sit unpacked in a 4-byte container.

The packed 3-byte `S24_3LE` / `S24_3BE` paths are **not** touched and were confirmed byte-identical to upstream. They reconstruct the sample left-justified into the full 32-bit range — a different convention that correctly calls for a different scale constant.

Comments explaining the reasoning are included at each site, since the two directions fail in visibly different ways.

## Verification

Diffed byte-for-byte against the deployed fix in `feature/multipath-v1`, where this has been running on hardware (RME Babyface Pro FS at 24-bit). I have not built this isolated branch itself — the change is four constants, but that's still a claim about a build I haven't run, so I'd rather say so.

## Provenance

As discussed in #555: I'm not a developer, and this is AI-implemented from my descriptions. Please review accordingly.

Targeting `main` since that's what the branch is based on — happy to retarget to `dev`.
