### PR TITLE
Recognize JUCE-exported sidechain port groups by name when pg:sideChainOf is absent

### DIFF
--- a/src/PluginHost.cpp
+++ b/src/PluginHost.cpp
@@ -51,6 +51,7 @@
 #include "util.hpp"
 #include "ModFileTypes.hpp"
 #include <algorithm>
+#include <cctype>
 
 #include "Locale.hpp"
 
@@ -647,6 +648,17 @@ static bool ports_sort_compare(std::shared_ptr<Lv2PortInfo> &p1, const std::shar
     return p1->index() < p2->index();
 }
 
+static bool isSidechainGroupName(const Lv2PortGroup &portGroup)
+{
+    std::string text = portGroup.name() + " " + portGroup.symbol();
+    std::transform(
+        text.begin(), text.end(), text.begin(),
+        [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return text.find("sidechain") != std::string::npos
+        || text.find("side chain") != std::string::npos
+        || text.find("side_chain") != std::string::npos;
+}
+
 bool Lv2PluginInfo::HasFactoryPresets(PluginHost *lv2Host, const LilvPlugin *plugin)
 {
     AutoLilvNodes nodes = lilv_plugin_get_related(plugin, lv2Host->lilvUris->presets__preset);
@@ -977,7 +989,9 @@ Lv2PluginInfo::Lv2PluginInfo(PluginHost *lv2Host, LilvWorld *pWorld, const LilvP
                 {
                     if (pg->uri() == port->port_group())
                     {
-                        if (!pg->sideChainOf().empty())
+                        // JUCE exports named sidechain groups but currently omits
+                        // pg:sideChainOf, so retain the semantic group-name fallback.
+                        if (!pg->sideChainOf().empty() || isSidechainGroupName(*pg))
                         {
                             port->is_sidechain(true);
                             audio_sidechain_title_ = pg->name();


### PR DESCRIPTION
## First, a correction

In #555 I implied the fork adds sidechain **input selection** — choosing a specific plugin's output as another plugin's sidechain source. That was wrong, and I should have checked before saying it.

Diffing against `upstream/main` directly: `sideChainInputId`, its `GetEffect()`-based resolution in `Lv2Pedalboard.cpp`, the `IEffect`/`Lv2Effect` plumbing and `SideChainSelectControl.tsx` are all **already in upstream, byte-for-byte identical to the fork**. There is nothing to contribute there. Sorry for the noise.

Your question about a send from a lower split branch to an upper one is also answered by that check: it isn't implemented, in the fork or upstream. Processing is strictly top-to-bottom in both, so that direction still incurs the one-buffer delay you described. That would be new work, not an extraction, and I'd want your input on the intended semantics before anyone attempts it.

## What this PR actually is

The one genuine gap I found while checking: LV2's proper way to mark a port group as a sidechain is `pg:sideChainOf`, which the existing detection in `PluginHost.cpp` checks. JUCE-generated LV2 exports — Dusk Multi-Comp is the case I hit — give their sidechain input a *named* port group but omit `pg:sideChainOf` entirely. The check silently fails and the plugin's sidechain input is treated as an ordinary audio input.

`isSidechainGroupName()` is a narrow fallback: it runs **only** when the proper property is absent, and matches only group names/symbols containing "sidechain", "side chain" or "side_chain", case-insensitively. Behaviour is unchanged for any plugin that declares `pg:sideChainOf` correctly.

Three lines of real logic plus a helper and one `#include`.

## Caveat worth your judgement

This is heuristic matching on a human-readable name, which is exactly the kind of thing that ages badly. It's here because JUCE's exporter omits a property it should emit — arguably the right fix is upstream in JUCE, and this is a workaround for their bug. If you'd rather not carry that, I understand; the alternative is that JUCE-generated plugins with sidechains stay unusable until JUCE changes.

## Verification

Not built. The change is small and mechanical, but I haven't compiled this branch, so I won't claim otherwise.

## Provenance

As discussed in #555: I'm not a developer, this is AI-implemented from my descriptions. Please review accordingly.

Targeting `main` since that's what the branch is based on — happy to retarget to `dev`.
