### PR TITLE
Support numeric (atom:Float) LV2 patch properties

### DIFF
--- a/src/PluginHost.cpp
+++ b/src/PluginHost.cpp
@@ -138,15 +138,22 @@ void PluginHost::LilvUris::Initialize(LilvWorld *pWorld)
     atom__bufferType = lilv_new_uri(pWorld, LV2_ATOM__bufferType);
     atom__Path = lilv_new_uri(pWorld, LV2_ATOM__Path);
     atom__String = lilv_new_uri(pWorld, LV2_ATOM__String);
+    atom__Float = lilv_new_uri(pWorld, LV2_ATOM__Float);
     presets__preset = lilv_new_uri(pWorld, LV2_PRESETS__Preset);
     state__state = lilv_new_uri(pWorld, LV2_STATE__state);
     rdfs__label = lilv_new_uri(pWorld, LILV_NS_RDFS "label");
+    rdf__value = lilv_new_uri(pWorld, LILV_NS_RDF "value");
 
     lv2core__symbol = lilv_new_uri(pWorld, LV2_CORE__symbol);
     lv2core__name = lilv_new_uri(pWorld, LV2_CORE__name);
     lv2core__shortName = lilv_new_uri(pWorld, LV2_CORE_PREFIX "shortName"); // ?? from mod sources
     lv2core__index = lilv_new_uri(pWorld, LV2_CORE__index);
     lv2core__Parameter = lilv_new_uri(pWorld, LV2_CORE_PREFIX "Parameter");
+    lv2core__minimum = lilv_new_uri(pWorld, LV2_CORE_PREFIX "minimum");
+    lv2core__maximum = lilv_new_uri(pWorld, LV2_CORE_PREFIX "maximum");
+    lv2core__default = lilv_new_uri(pWorld, LV2_CORE_PREFIX "default");
+    lv2core__portProperty = lilv_new_uri(pWorld, LV2_CORE_PREFIX "portProperty");
+    lv2core__scalePoint = lilv_new_uri(pWorld, LV2_CORE_PREFIX "scalePoint");
     lv2core__minorVersion = lilv_new_uri(pWorld, LV2_CORE__minorVersion);
     lv2core__microVersion = lilv_new_uri(pWorld, LV2_CORE__microVersion);
 
@@ -801,7 +808,10 @@ Lv2PluginInfo::FindWritablePathProperties(PluginHost *lv2Host, const LilvPlugin 
                 {
                     if (lilv_world_ask(pWorld, propertyUri, lv2Host->lilvUris->rdfs__range, lv2Host->lilvUris->atom__String))
                     {
-                        
+                        // String properties have no generic control, but they don't make a plugin unusable either.
+                    } else if (lilv_world_ask(pWorld, propertyUri, lv2Host->lilvUris->rdfs__range, lv2Host->lilvUris->atom__Float))
+                    {
+                        // Numeric patch properties are rendered with generic PiPedal controls.
                     } else {
                         std::string strPluginUri = pluginUri.AsUri();
                         if (strPluginUri == "urn:brummer:neuralrack") {
@@ -2217,6 +2227,11 @@ Lv2PatchPropertyInfo::Lv2PatchPropertyInfo(PluginHost *pluginHost, const LilvNod
     {
         this->type_ = range.AsUri();
     }
+    AutoLilvNode label = lilv_world_get(pWorld, propertyUri, pluginHost->lilvUris->rdfs__label, nullptr);
+    if (label)
+    {
+        this->label_ = label.AsString();
+    }
     AutoLilvNode comment = lilv_world_get(pWorld, propertyUri, pluginHost->lilvUris->rdfs__Comment, nullptr);
     if (comment)
     {
@@ -2247,6 +2262,45 @@ Lv2PatchPropertyInfo::Lv2PatchPropertyInfo(PluginHost *pluginHost, const LilvNod
         std::string strSupportedExtensions = modSupportedExtensionsNode.AsString();
         this->supportedExtensions_ = split(strSupportedExtensions, ',');
     }
+
+    // Range and presentation metadata, so a numeric patch property can be
+    // rendered with the same controls as an ordinary control port. Absent
+    // values fall back to a plain 0..1 range.
+    AutoLilvNode minValue = lilv_world_get(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__minimum, nullptr);
+    AutoLilvNode maxValue = lilv_world_get(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__maximum, nullptr);
+    AutoLilvNode defaultValue = lilv_world_get(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__default, nullptr);
+    this->minValue_ = minValue.AsFloat(0);
+    this->maxValue_ = maxValue.AsFloat(1);
+    this->defaultValue_ = defaultValue.AsFloat(this->minValue_);
+    this->logarithmic_ = lilv_world_ask(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__portProperty, pluginHost->lilvUris->port_logarithmic);
+    this->integer_ = lilv_world_ask(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__portProperty, pluginHost->lilvUris->integer_property_uri);
+    this->enumeration_ = lilv_world_ask(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__portProperty, pluginHost->lilvUris->enumeration_property_uri);
+    this->toggled_ = lilv_world_ask(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__portProperty, pluginHost->lilvUris->core__toggled);
+
+    AutoLilvNodes scalePointNodes = lilv_world_find_nodes(
+        pWorld, propertyUri, pluginHost->lilvUris->lv2core__scalePoint, nullptr);
+    LILV_FOREACH(nodes, iNode, scalePointNodes)
+    {
+        AutoLilvNode scalePointNode = lilv_nodes_get(scalePointNodes, iNode);
+        AutoLilvNode scalePointLabel = lilv_world_get(
+            pWorld, scalePointNode, pluginHost->lilvUris->rdfs__label, nullptr);
+        AutoLilvNode scalePointValue = lilv_world_get(
+            pWorld, scalePointNode, pluginHost->lilvUris->rdf__value, nullptr);
+        if (scalePointValue)
+        {
+            this->scalePoints_.emplace_back(
+                scalePointValue.AsFloat(0),
+                scalePointLabel ? scalePointLabel.AsString() : "");
+        }
+    }
+    std::sort(this->scalePoints_.begin(), this->scalePoints_.end(), scale_points_sort_compare);
 }
 
 // ffs.
@@ -2470,11 +2524,22 @@ json_map::storage_type<Lv2PluginUiInfo>
         }};
 JSON_MAP_BEGIN(Lv2PatchPropertyInfo)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, uri)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, writable)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, readable)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, label)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, index)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, type)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, comment)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, shortName)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, fileTypes)
 JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, supportedExtensions)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, minValue)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, maxValue)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, defaultValue)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, logarithmic)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, integer)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, enumeration)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, toggled)
+JSON_MAP_REFERENCE(Lv2PatchPropertyInfo, scalePoints)
 
 JSON_MAP_END()

--- a/src/PluginHost.hpp
+++ b/src/PluginHost.hpp
@@ -349,6 +349,14 @@ namespace pipedal
         std::string shortName_;
         std::vector<std::string> fileTypes_;
         std::vector<std::string> supportedExtensions_;
+        float minValue_ = 0;
+        float maxValue_ = 1;
+        float defaultValue_ = 0;
+        bool logarithmic_ = false;
+        bool integer_ = false;
+        bool enumeration_ = false;
+        bool toggled_ = false;
+        std::vector<Lv2ScalePoint> scalePoints_;
 
     public:
         Lv2PatchPropertyInfo() {}
@@ -364,6 +372,14 @@ namespace pipedal
         LV2_PROPERTY_GETSET(shortName);
         LV2_PROPERTY_GETSET(fileTypes);
         LV2_PROPERTY_GETSET(supportedExtensions);
+        LV2_PROPERTY_GETSET_SCALAR(minValue);
+        LV2_PROPERTY_GETSET_SCALAR(maxValue);
+        LV2_PROPERTY_GETSET_SCALAR(defaultValue);
+        LV2_PROPERTY_GETSET_SCALAR(logarithmic);
+        LV2_PROPERTY_GETSET_SCALAR(integer);
+        LV2_PROPERTY_GETSET_SCALAR(enumeration);
+        LV2_PROPERTY_GETSET_SCALAR(toggled);
+        LV2_PROPERTY_GETSET(scalePoints);
 
         DECLARE_JSON_MAP(Lv2PatchPropertyInfo);
     };
@@ -818,6 +834,7 @@ namespace pipedal
             AutoLilvNode atom__bufferType;
             AutoLilvNode atom__Path;
             AutoLilvNode atom__String;
+            AutoLilvNode atom__Float;
             AutoLilvNode presets__preset;
             AutoLilvNode state__state;
             AutoLilvNode rdfs__label;
@@ -826,6 +843,12 @@ namespace pipedal
             AutoLilvNode lv2core__shortName;
             AutoLilvNode lv2core__index;
             AutoLilvNode lv2core__Parameter;
+            AutoLilvNode lv2core__minimum;
+            AutoLilvNode lv2core__maximum;
+            AutoLilvNode lv2core__default;
+            AutoLilvNode lv2core__portProperty;
+            AutoLilvNode lv2core__scalePoint;
+            AutoLilvNode rdf__value;
             AutoLilvNode lv2core__minorVersion;
             AutoLilvNode lv2core__microVersion;
             AutoLilvNode pipedalUI__ui;

--- a/vite/src/pipedal/Lv2Plugin.tsx
+++ b/vite/src/pipedal/Lv2Plugin.tsx
@@ -1013,6 +1013,14 @@ export class Lv2PatchPropertyInfo {
         this.shortName = input.shortName;
         this.fileTypes = input.fileTypes;
         this.supportedExtensions = input.supportedExtensions;
+        this.minValue = input.minValue ?? 0;
+        this.maxValue = input.maxValue ?? 1;
+        this.defaultValue = input.defaultValue ?? this.minValue;
+        this.logarithmic = input.logarithmic ?? false;
+        this.integer = input.integer ?? false;
+        this.enumeration = input.enumeration ?? false;
+        this.toggled = input.toggled ?? false;
+        this.scalePoints = ScalePoint.deserialize_array(input.scalePoints ?? []);
         return this;
     }
     static deserialize_array(input: any): Lv2PatchPropertyInfo[] {
@@ -1032,6 +1040,38 @@ export class Lv2PatchPropertyInfo {
     shortName: string = "";
     fileTypes: string[] = [];
     supportedExtensions: string[] = [];
+    minValue: number = 0;
+    maxValue: number = 1;
+    defaultValue: number = 0;
+    logarithmic: boolean = false;
+    integer: boolean = false;
+    enumeration: boolean = false;
+    toggled: boolean = false;
+    scalePoints: ScalePoint[] = [];
+
+    isNumeric(): boolean {
+        return this.type === "http://lv2plug.in/ns/ext/atom#Float";
+    }
+
+    // Present a numeric patch property as if it were an ordinary control port,
+    // so that the standard control renderers can be re-used for it.
+    toUiControl(): UiControl {
+        return new UiControl().deserialize({
+            symbol: this.uri,
+            name: this.shortName || this.label || "Parameter",
+            index: this.index,
+            is_input: this.writable,
+            min_value: this.minValue,
+            max_value: this.maxValue,
+            default_value: this.defaultValue,
+            is_logarithmic: this.logarithmic,
+            integer_property: this.integer,
+            enumeration_property: this.enumeration,
+            toggled_property: this.toggled,
+            scale_points: this.scalePoints,
+            comment: this.comment
+        });
+    }
 };
 
 export class UiPlugin implements Deserializable<UiPlugin> {

--- a/vite/src/pipedal/PatchPropertyControl.tsx
+++ b/vite/src/pipedal/PatchPropertyControl.tsx
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 Thomas Rapolani
+// SPDX-License-Identifier: MIT
+
+import { useEffect, useMemo, useState } from "react";
+import { Lv2PatchPropertyInfo } from "./Lv2Plugin";
+import { ListenHandle, PiPedalModelFactory } from "./PiPedalModel";
+import PluginControl from "./PluginControl";
+
+interface PatchPropertyControlProps {
+    instanceId: number;
+    property: Lv2PatchPropertyInfo;
+}
+
+export default function PatchPropertyControl(props: PatchPropertyControlProps) {
+    const model = PiPedalModelFactory.getInstance();
+    const uiControl = useMemo(() => props.property.toUiControl(), [props.property]);
+    const [value, setValue] = useState(uiControl.default_value);
+
+    useEffect(() => {
+        let mounted = true;
+        let listenHandle: ListenHandle | undefined;
+
+        if (props.property.readable) {
+            listenHandle = model.monitorPatchProperty(
+                props.instanceId,
+                props.property.uri,
+                (_instanceId, _propertyUri, nextValue) => {
+                    if (mounted && typeof nextValue === "number") {
+                        setValue(nextValue);
+                    }
+                }
+            );
+            model.getPatchProperty<number>(props.instanceId, props.property.uri)
+                .then((nextValue) => {
+                    if (mounted && typeof nextValue === "number") {
+                        setValue(nextValue);
+                    }
+                })
+                .catch(() => {
+                    // Some plugins only report a value after the first patch:Set.
+                });
+        }
+
+        return () => {
+            mounted = false;
+            if (listenHandle) {
+                model.cancelMonitorPatchProperty(listenHandle);
+            }
+        };
+    }, [model, props.instanceId, props.property.readable, props.property.uri]);
+
+    const setPatchValue = (nextValue: number) => {
+        setValue(nextValue);
+        void model.setPatchProperty(props.instanceId, props.property.uri, nextValue)
+            .catch((error) => {
+                console.error(`Failed to set LV2 patch property ${props.property.uri}:`, error);
+                if (props.property.readable) {
+                    void model.getPatchProperty<number>(props.instanceId, props.property.uri)
+                        .then((currentValue) => {
+                            if (typeof currentValue === "number") {
+                                setValue(currentValue);
+                            }
+                        });
+                }
+            });
+    };
+
+    return (
+        <PluginControl
+            instanceId={props.instanceId}
+            uiControl={uiControl}
+            value={value}
+            onChange={setPatchValue}
+            onPreviewChange={() => { }}
+            requestIMEEdit={() => { }}
+        />
+    );
+}

--- a/vite/src/pipedal/PluginControlView.tsx
+++ b/vite/src/pipedal/PluginControlView.tsx
@@ -55,6 +55,7 @@ import ToobFrequencyResponseView from './ToobFrequencyResponseView';
 import ToolTipEx from './ToolTipEx';
 import MidiChannelBindingControl from './MidiChannelBindingControl';
 import MidiChannelBinding from './MidiChannelBinding';
+import PatchPropertyControl from './PatchPropertyControl';
 
 
 export const StandardItemSize = { width: 80, height: 110 };
@@ -707,6 +708,27 @@ const PluginControlView =
                             this.push_control(result, pluginControl, controlValues);
                         }
                     }
+                }
+                // Numeric (atom:Float) patch properties get generic controls, in
+                // lv2:index order, with the property label as a tiebreaker.
+                const numericPatchProperties = plugin.patchProperties
+                    .filter((property) => property.writable && property.isNumeric())
+                    .sort((left, right) => {
+                        const leftIndex = left.index < 0 ? Number.MAX_SAFE_INTEGER : left.index;
+                        const rightIndex = right.index < 0 ? Number.MAX_SAFE_INTEGER : right.index;
+                        if (leftIndex !== rightIndex) {
+                            return leftIndex - rightIndex;
+                        }
+                        return (left.label || left.uri).localeCompare(right.label || right.uri);
+                    });
+                for (const patchProperty of numericPatchProperties) {
+                    result.push(
+                        <PatchPropertyControl
+                            key={"patch-" + patchProperty.uri}
+                            instanceId={this.props.instanceId}
+                            property={patchProperty}
+                        />
+                    );
                 }
                 for (let i = 0; i < plugin.fileProperties.length; ++i) {
                     let fileProperty = plugin.fileProperties[i];


### PR DESCRIPTION
Draft — one topic extracted from my fork, as discussed by email. Not build-tested against your CI yet; the TypeScript side type-checks clean (`tsc -b --force`).

### Problem

`Lv2PluginInfo::FindWritablePathProperties` accepts a `patch:writable` `lv2:Parameter` only when its `rdfs:range` is `atom:Path` or `atom:String`. Anything else sets `unsupportedPatchProperty = true`, which removes the plugin from the plugin list entirely (with the one hard-coded exception for `urn:brummer:neuralrack`).

Several plugins put ordinary numeric knobs on patch properties instead of control ports — the Dusk Audio series is the case I ran into. They're not "unsupportable" in the sense that JUCE plugins are; they simply have no renderer.

### Change

* Accept `rdfs:range atom:Float` as a supported patch property (an empty branch alongside the existing `atom:String` one, so it no longer trips `unsupportedPatchProperty`).
* `Lv2PatchPropertyInfo` now also reads `lv2:minimum`, `lv2:maximum`, `lv2:default`, the `lv2:portProperty` flags (`logarithmic`, `integer`, `enumeration`, `toggled`) and `lv2:scalePoint` / `rdf:value`, plus `rdfs:label` — which was already in the JSON map and in the TypeScript class but was never populated on the C++ side.
* `writable`, `readable` and `index` are added to the JSON map for the same reason: `Lv2PatchPropertyInfo.deserialize()` in `Lv2Plugin.tsx` already reads them.
* New `PatchPropertyControl.tsx` renders one property using the existing `PluginControl`, driven by `Lv2PatchPropertyInfo.toUiControl()`. It uses `getPatchProperty` / `setPatchProperty` / `monitorPatchProperty` as they already exist, so there is no protocol change.
* `PluginControlView` appends the writable numeric properties (in `lv2:index` order) after the control ports and before the file properties.

### Scope notes

* Defaults are conservative: absent `lv2:minimum`/`maximum` give a plain 0..1 range, matching what LV2 says about parameters without a stated range.
* Non-writable (read-only) properties are not rendered.
* This deliberately does **not** touch `ModGuiHost`. Resolving MOD-GUI `mod-port-symbol` references to patch properties is a separate topic and a much larger diff; I've kept it out.
* No tests — I didn't see an existing pattern for testing plugin metadata parsing, and I'd rather follow yours than invent one. Happy to add whatever you'd like here.

Let me know if you'd prefer the range/scale-point parsing factored differently, or the rendering to live somewhere other than `PluginControlView`.
