### PR TITLE
Add data-pipedal-role styling hooks to the plugin control view

### DIFF
--- a/vite/src/pipedal/PluginControlView.tsx
+++ b/vite/src/pipedal/PluginControlView.tsx
@@ -635,6 +635,16 @@ const PluginControlView =
             isLandscapeGrid(): boolean {
                 return this.state.landscapeGrid;
             }
+            // The `data-pipedal-role` attributes emitted here and in
+            // controlNodesToNodes/renderPiPedalControl are a styling seam for
+            // custom plugin views: a view can wrap PluginControlView and restyle
+            // the control-group frames, titles and grid from its own stylesheet
+            // without this component having to know the plugin exists. The roles
+            // are "plugin-control-frame", "control-grid", "control-group",
+            // "control-group-title", "control-group-controls" and
+            // "custom-control"; `data-group-name` carries the LV2 port-group
+            // name so a view can style individual groups. They carry no
+            // behaviour and nothing reads them back.
             renderControlGroup(controlGroup: ControlGroup, key: string): ReactNode {
                 let isLandscapeGrid = this.state.landscapeGrid;
 
@@ -653,18 +663,21 @@ const PluginControlView =
                     );
                 }
                 return (
-                    <div key={key} className={!isLandscapeGrid ? classes.portGroup : classes.portGroupLandscape}
+                    <div key={key}
+                        data-pipedal-role="control-group"
+                        data-group-name={controlGroup.name}
+                        className={!isLandscapeGrid ? classes.portGroup : classes.portGroupLandscape}
                         style={{ borderWidth: (controlGroup.name === "" ? 0 : undefined) }}
                     >
                         {controlGroup.name !== "" && (
-                            <div className={classes.portGroupTitle}>
+                            <div data-pipedal-role="control-group-title" className={classes.portGroupTitle}>
                                 <ToolTipEx title={controlGroup.name}
                                 >
                                     <Typography noWrap variant="caption" >{controlGroup.name}</Typography>
                                 </ToolTipEx>
                             </div>
                         )}
-                        <div className={
+                        <div data-pipedal-role="control-group-controls" className={
                             this.state.landscapeGrid ? classes.portGroupControlsLandscape : classes.portGroupControls} >
                             {
                                 controls
@@ -849,7 +862,11 @@ const PluginControlView =
                             );
                         } else {
                             result.push((
-                                <div key={"ctl" + (this.controlKeyIndex++)} className={hasGroups ? classes.portgroupControlPadding : classes.controlPadding} >
+                                <div
+                                    key={"ctl" + (this.controlKeyIndex++)}
+                                    data-pipedal-role="custom-control"
+                                    className={hasGroups ? classes.portgroupControlPadding : classes.controlPadding}
+                                >
                                     {node as ReactNode}
                                 </div>
                             ));
@@ -1025,7 +1042,7 @@ const PluginControlView =
                 }
                 return (
                     <div className={scrollClass}>
-                        <div className={gridClass}  >
+                        <div data-pipedal-role="control-grid" className={gridClass}>
                             {
                                 nodes
                             }
@@ -1066,7 +1083,7 @@ const PluginControlView =
 
 
                 return (
-                    <div className={frameClass}>
+                    <div data-pipedal-role="plugin-control-frame" className={frameClass}>
                         <div className={classes.vuMeterL}>
                             <VuMeter displayText={true} display="input" instanceId={pedalboardItem.instanceId} />
                         </div>


### PR DESCRIPTION
Draft. This is the piece behind the control-group restyling you singled out — extracted on its own, because on inspection it turned out to be the only part that belongs in core.

**To answer your question first: no, this is not copied from Helix.** There is no Helix-derived layout, artwork or colour in it. The whole change is six data attributes. The look you liked comes from a *plugin view's own stylesheet* using these attributes as selectors — for Dragonfly, squared-off group frames (`border-radius: 0`), flush panels separated by hairlines, inline uppercase titles and a coloured top rule per group, in Dragonfly's own dark palette. Coloured group headers are a common plugin/DAW convention rather than anything specific to Helix, and if you'd rather a given skin didn't use them, that's a per-skin decision — nothing here imposes it.

### The problem

Custom plugin views wrap `PluginControlView`, but they have no way to restyle what it renders. The control-group frame, its title, the control grid and the outer frame are addressable only through generated Emotion class names, which are not a stable API. So a custom view can add controls, but it cannot change how the standard groups look.

### The change

Stable data attributes on the relevant elements:

| attribute value | element |
|---|---|
| `plugin-control-frame` | outer frame |
| `control-grid` | the control grid |
| `control-group` | one port-group box |
| `control-group-title` | its title |
| `control-group-controls` | the controls inside it |
| `custom-control` | a non-group control cell |

plus `data-group-name` on each group, carrying the LV2 port-group name, so a view can style individual groups by name.

Attributes only — no behaviour change, no new dependency, nothing reads them back, and the default appearance is byte-for-byte unchanged. A short comment above `renderControlGroup` documents the contract.

Verified with `npx tsc -b --force` (exit 0).

### Note on #562

I should flag this: **[#562](https://github.com/rerdavies/pipedal/pull/562) as I first submitted it does not work without this PR.** `DragonflyView` styles everything through these selectors, and I extracted the view without noticing the attributes it depends on were still only in my fork's `PluginControlView`. On `main` as it stands, none of those selectors match anything and the skin renders as an unstyled control view with a dark background. My mistake — I've now added this commit to that branch too, so #562 is self-consistent; if you merge this one first, the duplicate commit drops out cleanly.

### Open question

Whether you'd rather have this as data attributes or as stable class names. Attributes keep it clearly out of the Emotion/tss styling path and make it obvious they're a contract rather than styling, but classes would be more conventional. Your call — it's a mechanical change either way.
