### PR TITLE
Add a MIDI monitor for diagnosing controller input

### DIFF
--- a/src/AudioHost.cpp
+++ b/src/AudioHost.cpp
@@ -944,7 +944,22 @@ private:
             event, this, fnMidiValueChanged);
         if (listenForMidiEvent)
         {
-            if (event.size >= 3)
+            if (monitorAllMidiEvents)
+            {
+                // Diagnostics: report the message as received, with no
+                // filtering, so the monitor shows what the device actually
+                // sent. Per-listener filtering happens in PiPedalModel, so
+                // MIDI learn still sees only what it can bind to.
+                if (event.size >= 1)
+                {
+                    MidiNotifyBody notifyBody(
+                        event.buffer[0],
+                        event.size >= 2 ? event.buffer[1] : (uint8_t)0,
+                        event.size >= 3 ? event.buffer[2] : (uint8_t)0);
+                    realtimeWriter.OnMidiListen(notifyBody);
+                }
+            }
+            else if (event.size >= 3)
             {
                 uint8_t cmd = (uint8_t)(event.buffer[0] & 0xF0);
                 bool isNote = cmd == 0x90 && event.buffer[2] != 0; // note on with velocity > 0.
@@ -2356,11 +2371,16 @@ public:
         return result;
     }
     std::atomic<bool> listenForMidiEvent = false;
+    std::atomic<bool> monitorAllMidiEvents = false;
     std::atomic<bool> listenForAtomOutput = false;
 
     virtual void SetListenForMidiEvent(bool listen)
     {
         this->listenForMidiEvent = listen;
+    }
+    virtual void SetMonitorAllMidiEvents(bool monitor)
+    {
+        this->monitorAllMidiEvents = monitor;
     }
     virtual void SetListenForAtomOutput(bool listen)
     {

--- a/src/AudioHost.hpp
+++ b/src/AudioHost.hpp
@@ -222,6 +222,10 @@ namespace pipedal
         virtual void SetNotificationCallbacks(IAudioHostCallbacks *pNotifyCallbacks) = 0;
 
         virtual void SetListenForMidiEvent(bool listen) = 0;
+        // When set, every MIDI channel-voice message is reported to
+        // OnNotifyMidiListen, not just the note-on/control-change subset that
+        // MIDI learn can bind to. Used by the MIDI monitor.
+        virtual void SetMonitorAllMidiEvents(bool monitor) = 0;
         virtual void SetListenForAtomOutput(bool listen) = 0;
 
         //virtual bool UpdatePluginStates(Pedalboard &pedalboard) = 0;

--- a/src/PiPedalModel.cpp
+++ b/src/PiPedalModel.cpp
@@ -2648,10 +2648,26 @@ void PiPedalModel::DeleteMidiListeners(int64_t clientId)
             --i;
         }
     }
-    if (audioHost)
+    UpdateMidiListenerState();
+}
+
+void PiPedalModel::UpdateMidiListenerState()
+{
+    if (!audioHost)
     {
-        audioHost->SetListenForMidiEvent(midiEventListeners.size() != 0);
+        return;
     }
+    bool monitorAll = false;
+    for (const auto &listener : midiEventListeners)
+    {
+        if (listener.listenForAllEvents)
+        {
+            monitorAll = true;
+            break;
+        }
+    }
+    audioHost->SetListenForMidiEvent(midiEventListeners.size() != 0);
+    audioHost->SetMonitorAllMidiEvents(monitorAll);
 }
 
 void PiPedalModel::OnPatchSetReply(uint64_t instanceId, LV2_URID patchSetProperty, const LV2_Atom *atomValue)
@@ -2758,19 +2774,17 @@ void PiPedalModel::OnNotifyMidiListen(uint8_t cc0, uint8_t cc1, uint8_t cc2)
 {
     std::lock_guard<std::recursive_mutex> lock(mutex);
     bool isNote = (cc0 & 0xF0) == 0x90; // Note On
-    if (isNote && cc2 == 0)
-    {
-        return; // Note off. Oopsie.
-    }
     bool isControl = (cc0 & 0xF0) == 0xB0; // Control Change
-    if (!isNote && !isControl)
-    {
-        return; // Not a note on or control change.
-    }
+    // What MIDI learn is able to bind to. Monitor listeners get everything.
+    bool isBindable = (isNote && cc2 != 0) || isControl;
 
     for (int i = 0; i < midiEventListeners.size(); ++i)
     {
         auto &listener = midiEventListeners[i];
+        if (!listener.listenForAllEvents && !isBindable)
+        {
+            continue;
+        }
         auto subscriber = this->GetNotificationSubscriber(listener.clientId);
         if (subscriber)
         {
@@ -2782,15 +2796,15 @@ void PiPedalModel::OnNotifyMidiListen(uint8_t cc0, uint8_t cc1, uint8_t cc2)
             --i;
         }
     }
-    audioHost->SetListenForMidiEvent(midiEventListeners.size() != 0);
+    UpdateMidiListenerState();
 }
 
-void PiPedalModel::ListenForMidiEvent(int64_t clientId, int64_t clientHandle)
+void PiPedalModel::ListenForMidiEvent(int64_t clientId, int64_t clientHandle, bool listenForAllEvents)
 {
     std::lock_guard<std::recursive_mutex> lock(mutex);
-    MidiListener listener{clientId, clientHandle};
+    MidiListener listener{clientId, clientHandle, listenForAllEvents};
     midiEventListeners.push_back(listener);
-    audioHost->SetListenForMidiEvent(true);
+    UpdateMidiListenerState();
 }
 
 void PiPedalModel::CancelListenForMidiEvent(int64_t clientId, int64_t clientHandle)
@@ -2805,10 +2819,7 @@ void PiPedalModel::CancelListenForMidiEvent(int64_t clientId, int64_t clientHand
             break;
         }
     }
-    if (midiEventListeners.size() == 0)
-    {
-        audioHost->SetListenForMidiEvent(false);
-    }
+    UpdateMidiListenerState();
 }
 
 void PiPedalModel::MonitorPatchProperty(int64_t clientId, int64_t clientHandle, uint64_t instanceId, const std::string &propertyUri)

--- a/src/PiPedalModel.hpp
+++ b/src/PiPedalModel.hpp
@@ -164,6 +164,9 @@ namespace pipedal
         public:
             int64_t clientId;
             int64_t clientHandle;
+            // MIDI learn wants only bindable messages; the MIDI monitor wants
+            // everything the device sends.
+            bool listenForAllEvents = false;
         };
         class AtomOutputListener
         {
@@ -180,6 +183,9 @@ namespace pipedal
             LV2_URID propertyUrid;
         };
         void DeleteMidiListeners(int64_t clientId);
+        // Recomputes the two audio-host flags from the current listener set.
+        // Call with the mutex held after any change to midiEventListeners.
+        void UpdateMidiListenerState();
         void DeleteAtomOutputListeners(int64_t clientId);
 
         std::vector<MidiListener> midiEventListeners;
@@ -490,7 +496,7 @@ namespace pipedal
         JackServerSettings GetJackServerSettings();
         void SetJackServerSettings(const JackServerSettings &jackServerSettings);
 
-        void ListenForMidiEvent(int64_t clientId, int64_t clientHandle);
+        void ListenForMidiEvent(int64_t clientId, int64_t clientHandle, bool listenForAllEvents = false);
         void CancelListenForMidiEvent(int64_t clientId, int64_t clientHandle);
 
         void MonitorPatchProperty(int64_t clientId, int64_t clientHandle, uint64_t instanceId, const std::string &propertyUri);

--- a/src/PiPedalSocket.cpp
+++ b/src/PiPedalSocket.cpp
@@ -1276,6 +1276,17 @@ public:
     }
     REGISTER_MESSAGE_HANDLER(listenForMidiEvent)
 
+    // Same listener list as listenForMidiEvent, but the listener receives every
+    // MIDI channel-voice message instead of only the ones MIDI learn can bind
+    // to. Cancelled with cancelListenForMidiEvent.
+    void handle_monitorMidiEvents(int replyTo, json_reader *pReader)
+    {
+        ListenForMidiEventBody body;
+        pReader->read(&body);
+        this->model.ListenForMidiEvent(this->clientId, body.handle_, true);
+    }
+    REGISTER_MESSAGE_HANDLER(monitorMidiEvents)
+
     void handle_cancelListenForMidiEvent(int replyTo, json_reader *pReader)
     {
         uint64_t handle;

--- a/vite/src/pipedal/MidiMonitorDialog.tsx
+++ b/vite/src/pipedal/MidiMonitorDialog.tsx
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Thomas Rapolani
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import { useEffect, useRef, useState } from 'react';
+import AppBar from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+import DialogEx from './DialogEx';
+import IconButtonEx from './IconButtonEx';
+import { ListenHandle, MidiMessage, PiPedalModelFactory } from './PiPedalModel';
+
+// Keep the list bounded: a controller sending continuous CCs would otherwise
+// grow it without limit while the dialog is open.
+const MAX_ENTRIES = 200;
+
+interface MidiMonitorEntry {
+    key: number;
+    time: string;
+    channel: string;
+    type: string;
+    detail: string;
+}
+
+const NOTE_NAMES = ["C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"];
+
+function noteName(note: number): string {
+    // Middle C (note 60) is C4, matching the convention used elsewhere in the UI.
+    return `${NOTE_NAMES[note % 12]}${Math.floor(note / 12) - 1}`;
+}
+
+function describe(message: MidiMessage): { channel: string, type: string, detail: string } {
+    const status = message.cc0 & 0xF0;
+    const channel = `${(message.cc0 & 0x0F) + 1}`;
+    switch (status) {
+        case 0x80:
+            return { channel, type: "Note Off", detail: `${noteName(message.cc1)} (${message.cc1}) vel ${message.cc2}` };
+        case 0x90:
+            return message.cc2 === 0
+                ? { channel, type: "Note Off", detail: `${noteName(message.cc1)} (${message.cc1}) vel 0` }
+                : { channel, type: "Note On", detail: `${noteName(message.cc1)} (${message.cc1}) vel ${message.cc2}` };
+        case 0xA0:
+            return { channel, type: "Aftertouch", detail: `${noteName(message.cc1)} (${message.cc1}) ${message.cc2}` };
+        case 0xB0:
+            return { channel, type: "Control Change", detail: `CC ${message.cc1} = ${message.cc2}` };
+        case 0xC0:
+            return { channel, type: "Program Change", detail: `program ${message.cc1}` };
+        case 0xD0:
+            return { channel, type: "Channel Pressure", detail: `${message.cc1}` };
+        case 0xE0:
+            return { channel, type: "Pitch Bend", detail: `${((message.cc2 << 7) | message.cc1) - 8192}` };
+        default:
+            return {
+                channel: "-",
+                type: "System",
+                detail: `0x${message.cc0.toString(16)} ${message.cc1} ${message.cc2}`
+            };
+    }
+}
+
+export interface MidiMonitorDialogProps {
+    open: boolean;
+    onClose: () => void;
+}
+
+export default function MidiMonitorDialog(props: MidiMonitorDialogProps) {
+    const { open, onClose } = props;
+    const [entries, setEntries] = useState<MidiMonitorEntry[]>([]);
+    const [paused, setPaused] = useState(false);
+    const pausedRef = useRef(paused);
+    const nextKey = useRef(0);
+
+    pausedRef.current = paused;
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const model = PiPedalModelFactory.getInstance();
+        let listenHandle: ListenHandle | undefined = model.monitorMidiEvents(
+            (message: MidiMessage) => {
+                if (pausedRef.current) {
+                    return;
+                }
+                const described = describe(message);
+                const entry: MidiMonitorEntry = {
+                    key: nextKey.current++,
+                    time: new Date().toLocaleTimeString(),
+                    ...described
+                };
+                // Newest first, so the interesting end needs no scrolling.
+                setEntries((previous) => [entry, ...previous].slice(0, MAX_ENTRIES));
+            });
+
+        return () => {
+            if (listenHandle) {
+                model.cancelListenForMidiEvent(listenHandle);
+                listenHandle = undefined;
+            }
+        };
+    }, [open]);
+
+    if (!open) {
+        return (<div />);
+    }
+
+    return (
+        <DialogEx tag="midiMonitor" open={open} fullWidth fullScreen
+            onClose={onClose}
+            style={{ userSelect: "none" }}
+            onEnterKey={() => { }}
+        >
+            <div style={{
+                display: "flex", flexDirection: "column", flexWrap: "nowrap",
+                width: "100%", height: "100%", overflow: "hidden"
+            }}>
+                <div style={{ flex: "0 0 auto" }}>
+                    <AppBar style={{ position: "relative" }}>
+                        <Toolbar>
+                            <IconButtonEx tooltip="Back" edge="start" color="inherit"
+                                onClick={onClose} aria-label="back" size="large">
+                                <ArrowBackIcon />
+                            </IconButtonEx>
+                            <Typography variant="h6" style={{ flex: "1 1 auto", marginLeft: 16 }}>
+                                MIDI Monitor
+                            </Typography>
+                            <IconButtonEx tooltip={paused ? "Resume" : "Pause"} color="inherit"
+                                onClick={() => setPaused(!paused)}
+                                aria-label={paused ? "resume" : "pause"} size="large">
+                                {paused ? <PlayArrowIcon /> : <PauseIcon />}
+                            </IconButtonEx>
+                            <IconButtonEx tooltip="Clear" color="inherit"
+                                onClick={() => setEntries([])} aria-label="clear" size="large">
+                                <DeleteIcon />
+                            </IconButtonEx>
+                        </Toolbar>
+                    </AppBar>
+                </div>
+                <div style={{ overflow: "auto", flex: "1 1 auto", width: "100%", padding: 16 }}>
+                    {entries.length === 0 && (
+                        <Typography variant="body2" color="textSecondary">
+                            {paused
+                                ? "Paused."
+                                : "Waiting for MIDI input. Every incoming message is shown, including ones that cannot be bound to."}
+                        </Typography>
+                    )}
+                    {entries.map((entry) => (
+                        <div key={entry.key} style={{
+                            display: "flex", flexDirection: "row", flexWrap: "nowrap",
+                            gap: 16, alignItems: "baseline"
+                        }}>
+                            <Typography variant="caption" color="textSecondary"
+                                style={{ flex: "0 0 auto", minWidth: 76 }}>
+                                {entry.time}
+                            </Typography>
+                            <Typography variant="body2" style={{ flex: "0 0 auto", minWidth: 40 }}>
+                                {entry.channel === "-" ? "-" : `Ch ${entry.channel}`}
+                            </Typography>
+                            <Typography variant="body2" style={{ flex: "0 0 auto", minWidth: 130 }}>
+                                {entry.type}
+                            </Typography>
+                            <Typography variant="body2" color="textSecondary" noWrap
+                                style={{ flex: "1 1 auto", minWidth: 0 }}>
+                                {entry.detail}
+                            </Typography>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </DialogEx>
+    );
+}

--- a/vite/src/pipedal/PiPedalModel.tsx
+++ b/vite/src/pipedal/PiPedalModel.tsx
@@ -2937,6 +2937,20 @@ export class PiPedalModel //implements PiPedalModel
 
     }
 
+    // Like listenForMidiEvent, but receives every MIDI channel-voice message
+    // instead of only the ones MIDI learn can bind to. Cancel with
+    // cancelListenForMidiEvent.
+    monitorMidiEvents(onReceived: (midiMessage: MidiMessage) => void): ListenHandle {
+        let handle = this.nextListenHandle++;
+
+        this.midiListeners.push(new MidiEventListener(handle, onReceived));
+
+        this.webSocket?.send("monitorMidiEvents", { handle: handle });
+        return {
+            _handle: handle
+        };
+    }
+
     monitorPatchProperty(
         instanceId: number,
         propertyUri: string,

--- a/vite/src/pipedal/SystemMidiBindingsDialog.tsx
+++ b/vite/src/pipedal/SystemMidiBindingsDialog.tsx
@@ -41,6 +41,8 @@ import IconButtonEx from './IconButtonEx';
 import MidiBinding from './MidiBinding';
 import SystemMidiBindingView from './SystemMidiBindingView';
 import Snackbar from '@mui/material/Snackbar';
+import MidiMonitorDialog from './MidiMonitorDialog';
+import TuneIcon from '@mui/icons-material/Tune';
 
 const styles = (theme: Theme) => createStyles({
     dialogAppBar: css({
@@ -103,6 +105,7 @@ export interface SystemMidiBindingDialogState {
     listenSymbol: string;
     listenSnackbarOpen: boolean;
     systemMidiBindings: BindingEntry[];
+    midiMonitorOpen: boolean;
 
 }
 
@@ -119,7 +122,8 @@ export const SystemMidiBindingDialog =
                     listenInstanceId: -2,
                     listenSymbol: "",
                     listenSnackbarOpen: false,
-                    systemMidiBindings: this.createBindings()
+                    systemMidiBindings: this.createBindings(),
+                    midiMonitorOpen: false
                 };
                 this.handleClose = this.handleClose.bind(this);
                 this.onMidiBindingsChanged = this.onMidiBindingsChanged.bind(this);
@@ -289,6 +293,14 @@ export const SystemMidiBindingDialog =
                                         <Typography variant="h6" className={classes.dialogTitle}>
                                             System MIDI Bindings
                                         </Typography>
+                                        <IconButtonEx
+                                            tooltip="MIDI monitor"
+                                            color="inherit"
+                                            onClick={() => this.setState({ midiMonitorOpen: true })}
+                                            aria-label="midi monitor"
+                                            size="large">
+                                            <TuneIcon />
+                                        </IconButtonEx>
                                     </Toolbar>
                                 </AppBar>
                             </div>
@@ -315,6 +327,10 @@ export const SystemMidiBindingDialog =
                             autoHideDuration={1500}
                             onClose={() => this.setState({ listenSnackbarOpen: false })}
                             message="Listening for MIDI input"
+                        />
+                        <MidiMonitorDialog
+                            open={this.state.midiMonitorOpen}
+                            onClose={() => this.setState({ midiMonitorOpen: false })}
                         />
                     </DialogEx >
                 );


### PR DESCRIPTION
Draft — the diagnostics half of the MIDI work, which you said you had no objection to. Deliberately carries none of the Control Hub / controller-profile / per-snapshot-action material that overlaps with your MIDI Mappings roadmap.

Two things up front, so you can judge how hard to look at it:

- **The C++ has not been compiled.** I don't have a Linux build environment. The TypeScript is clean under `tsc -b --force`. Everything else is code review only.
- This is **not an extraction** from my fork like the others. In my fork the monitor lives inside the Control Hub dialog, which is exactly the part you asked to defer, so I rewrote it standalone against `main`. That means it's new code, not code that has been running on my Pi.

### The problem

There is no way to see what a controller is actually sending. The only path that reports incoming MIDI to a client is MIDI learn, and by design it reports only what it can bind to: note-on with non-zero velocity, and control change minus bank select and CC LSB. Everything else is dropped twice — once in the realtime filter in `ProcessMidiMonitor`, and again in `PiPedalModel::OnNotifyMidiListen`. So when a footswitch appears to do nothing, there is nothing to look at, and no way to tell "the device sent nothing" from "the device sent a program change and PiPedal ignored it".

### The change

A monitor mode alongside MIDI learn rather than a parallel pipeline:

- `MidiListener` gains `listenForAllEvents`. The filter in `OnNotifyMidiListen` becomes per-listener, so **learn clients receive exactly the set of messages they received before** — the note-off and non-note/CC drops are preserved for them verbatim.
- A new `monitorMidiEvents` socket message reuses the existing listener list; cancelled with the existing `cancelListenForMidiEvent`. The `listenForMidiEvent` message is untouched, so there is no wire-compatibility question for existing clients.
- `SetMonitorAllMidiEvents` on the audio host makes the realtime filter pass messages through unmodified while a monitor is attached, and only then.
- The three places that separately recomputed the listen flag now share `UpdateMidiListenerState()`.

The UI is a read-only full-screen dialog reached from a toolbar button in System MIDI Bindings. Newest-first list of decoded messages (time, channel, type, data), pause and clear. Bounded to 200 entries so a controller streaming CCs can't grow it without limit.

### Things worth your judgement

- **Placement.** I put the entry point in the System MIDI Bindings toolbar because that's where someone goes when a controller misbehaves. If MIDI Mappings is about to become something else, this button should probably move with it.
- **Realtime cost.** While a monitor is open, every channel-voice message writes a `MidiNotifyBody` to the ring buffer instead of only bindable ones. For a controller that streams CCs that's a higher rate than learn ever produced. It's bounded by MIDI bandwidth and only happens while the dialog is open, but you know that ring buffer's headroom better than I do — if you'd rather it coalesced or rate-limited, say so.
- I left `CancelMonitorAtomOutput`'s `midiEventListeners.size()` check alone. It looks like a copy-paste (it's in the atom-output path), but it's pre-existing and unrelated, and I didn't want to bury it in this diff.

Happy to drop the UI entirely and land just the backend if you'd rather build the dialog yourself.
