### PR TITLE
Modernize web UI: theme consistency, plugin browser navigation, a11y

### DIFF
--- a/vite/index.html
+++ b/vite/index.html
@@ -12,15 +12,19 @@
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="/css/modGui.css" />
+    <!-- These two are the pre-React body colours -- they paint before the MUI theme
+         loads and show through the loading/error scrims. They must track palette
+         background.default in App.tsx (light #FAFAFA, dark #16141d); the old #D0D0D0/#333 were
+         from the previous palette and flashed a mismatched grey on every start. -->
     <style>
         BODY {
-            background: #D0D0D0;
+            background: #FAFAFA;
         }
     </style>
 
     <style id="bgStyle">
         BODY {
-            background: #333; 
+            background: #16141d;
             overscroll-behavior: none;
         }
     </style>

--- a/vite/src/pipedal/App.tsx
+++ b/vite/src/pipedal/App.tsx
@@ -20,11 +20,13 @@
 import React from 'react';
 
 import { ThemeProvider, createTheme, StyledEngineProvider } from '@mui/material/styles';
+import { type Theme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
 import VirtualKeyboardHandler from './VirtualKeyboardHandler';
 import AppThemed from "./AppThemed";
 import { isDarkMode } from './DarkMode';
+import { appBarBackgroundImage, hairlineColor } from './ThemeSurfaces';
 import Tone3000AuthComplete from './Tone3000AuthComplete';
 import FontTest from './FontTest';
 
@@ -64,175 +66,268 @@ declare module '@mui/material/Button' {
 
 
 
+// `any`: MUI v6 requires `variants: []` on every styleOverrides entry once any entry
+// sets `variants`, which buys nothing here.
+const sharedComponents = (isDark: boolean): any => ({
+    MuiCssBaseline: {
+        styleOverrides: {
+            html: {
+                WebkitFontSmoothing: 'antialiased',
+                MozOsxFontSmoothing: 'grayscale',
+            },
+            body: {
+                textRendering: 'optimizeLegibility',
+            },
+            img: {
+                outline: `1px solid ${hairlineColor(isDark)}`,
+                outlineOffset: '-1px',
+            },
+        },
+    },
+    MuiAppBar: {
+        styleOverrides: {
+            root: {
+                backgroundImage: appBarBackgroundImage(isDark),
+                backdropFilter: 'blur(10px)',
+                WebkitBackdropFilter: 'blur(10px)',
+                boxShadow: isDark
+                    ? '0 1px 0 0 rgba(255,255,255,0.04), 0 4px 16px rgba(0,0,0,0.35)'
+                    : '0 1px 0 0 rgba(0,0,0,0.04), 0 4px 16px rgba(103,80,164,0.08)',
+                color: 'inherit',
+            },
+        },
+    },
+    MuiDrawer: {
+        styleOverrides: {
+            paper: {
+                backgroundImage: isDark
+                    ? 'linear-gradient(180deg, #221f2c 0%, #1a1822 100%)'
+                    : 'linear-gradient(180deg, #ffffff 0%, #faf8fd 100%)',
+                borderRight: `1px solid ${hairlineColor(isDark)}`,
+                boxShadow: isDark
+                    ? '0 0 40px rgba(0,0,0,0.5)'
+                    : '0 0 40px rgba(103,80,164,0.12)',
+            },
+        },
+    },
+    MuiPaper: {
+        styleOverrides: {
+            root: {
+                backgroundImage: 'none',
+            },
+            rounded: {
+                borderRadius: 12,
+            },
+            elevation1: { boxShadow: isDark ? '0 1px 2px rgba(0,0,0,0.4)' : '0 1px 2px rgba(0,0,0,0.06)' },
+            elevation2: { boxShadow: isDark ? '0 2px 8px rgba(0,0,0,0.4)' : '0 2px 8px rgba(0,0,0,0.08)' },
+            elevation4: { boxShadow: isDark ? '0 4px 16px rgba(0,0,0,0.5)' : '0 4px 16px rgba(0,0,0,0.10)' },
+        },
+    },
+    MuiDialog: {
+        styleOverrides: {
+            paper: {
+                borderRadius: 16,
+                boxShadow: isDark
+                    ? '0 24px 64px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04)'
+                    : '0 24px 64px rgba(103,80,164,0.18), 0 0 0 1px rgba(0,0,0,0.04)',
+            },
+        },
+    },
+    MuiButton: {
+        styleOverrides: {
+            root: {
+                '& .MuiTouchRipple-root': { borderRadius: 'inherit' },
+                '& .MuiTouchRipple-ripple': { transform: 'scale(1.9)' },
+            },
+            containedPrimary: {
+                borderRadius: '9999px',
+                paddingLeft: '16px', paddingRight: '16px',
+                textTransform: 'none',
+                fontWeight: 600,
+                boxShadow: 'none',
+                '&:hover': {
+                    boxShadow: isDark ? '0 4px 12px rgba(167,112,228,0.35)' : '0 4px 12px rgba(103,80,164,0.25)',
+                },
+            },
+            containedSecondary: {
+                borderRadius: '9999px',
+                paddingLeft: '16px', paddingRight: '16px',
+                textTransform: 'none',
+                fontWeight: 600,
+            },
+        },
+        variants: [
+            {
+                props: { variant: 'dialogPrimary' },
+                style: { color: isDark ? '#FFFFFF' : 'rgb(0,0,0,0.87)' },
+            },
+            {
+                props: { variant: 'dialogSecondary' },
+                style: { color: isDark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.6)' },
+            },
+        ],
+    },
+    MuiIconButton: {
+        styleOverrides: {
+            root: {
+                padding: 8,
+                borderRadius: 10,
+                transition: 'background-color 150ms ease-out, color 150ms ease-out, transform 120ms ease-out',
+                '&:active': { transform: 'scale(0.94)' },
+            },
+        },
+    },
+    MuiSwitch: {
+        styleOverrides: {
+            root: {
+                // Thumb centring depends on switchBase.padding + thumb/2 === root.height/2 (by default
+                // 9 + 20/2 === 38/2), so root width/height/padding and switchBase padding must not be
+                // overridden piecemeal here. Non-geometric polish only.
+                '& .MuiSwitch-thumb': {
+                    boxShadow: '0 1px 3px rgba(0,0,0,0.3)',
+                },
+                '& .MuiSwitch-track': {
+                    borderRadius: 999,
+                    opacity: isDark ? 0.45 : 0.6,
+                },
+            },
+        },
+    },
+    MuiListItemButton: {
+        styleOverrides: {
+            root: ({ theme }: { theme: Theme }) => ({
+                transition: 'background-color 150ms ease-out, color 150ms ease-out',
+                borderRadius: 8,
+                margin: '2px 8px',
+                padding: '8px 12px',
+                '&.Mui-selected': {
+                    backgroundColor: isDark ? 'rgba(167,112,228,0.18)' : 'rgba(103,80,164,0.12)',
+                    '&:hover': {
+                        backgroundColor: isDark ? 'rgba(167,112,228,0.24)' : 'rgba(103,80,164,0.16)',
+                    },
+                },
+                '&:hover': {
+                    backgroundColor: isDark ? 'rgba(255,255,255,0.05)' : 'rgba(0,0,0,0.04)',
+                },
+            }),
+        },
+    },
+    MuiToolbar: {
+        styleOverrides: {
+            dense: {
+                minHeight: 56,
+                paddingLeft: 8,
+                paddingRight: 8,
+            },
+        },
+    },
+    MuiDivider: {
+        styleOverrides: {
+            root: {
+                borderColor: hairlineColor(isDark),
+                margin: '4px 0',
+            },
+        },
+    },
+    MuiTooltip: {
+        styleOverrides: {
+            tooltip: {
+                backgroundColor: isDark ? 'rgba(40,36,52,0.96)' : 'rgba(40,36,52,0.96)',
+                color: '#FFFFFF',
+                borderRadius: 8,
+                padding: '8px 12px',
+                fontSize: '0.75rem',
+                boxShadow: '0 4px 16px rgba(0,0,0,0.3)',
+            },
+            arrow: {
+                color: 'rgba(40,36,52,0.96)',
+            },
+        },
+    },
+});
+
 const theme = createTheme(
     isDarkMode() ?
         {
             cssVariables: true,
-            components: {
-                // MuiTouchRipple: {
-                //     styleOverrides: {
-                //         root: {
-                //             borderRadius: 'inherit',
-                //             overflow: 'hidden',
-                //         },
-                //         ripple: {
-                //             color: '#F88 !important',
-                //             borderRadius: 'inherit',
-
-                //             '&.MuiTouchRipple-ripplePulsate': {
-                //                 //animation: 'none !important',
-
-                //                 // Make focus ripple fill the entire button
-                //                 '&.MuiTouchRipple-child': {
-                //                     width: '100%',
-                //                     height: '100%',
-                //                     borderRadius: 'inherit',
-                //                     transform: 'scale(1.4)', // Override the default scaling
-                //                 }
-                //             },
-                //             '&.MuiTouchRipple-ripple': {
-                //                 '&:focus': {
-                //                     // Make focus ripple fill the entire button
-                //                     transform: 'scale(1.4)',
-                //                     width: '100%',
-                //                     height: '100%',
-                //                     color: '#F88',
-                //                     borderRadius: 'inherit',
-                //                 },
-                //             },
-                //         },
-                //         child: {
-                //             borderRadius: 'inherit',
-                //         }
-                //     }
-                // },
-                MuiButton: {
-                    styleOverrides: {
-                        root: {
-                            '& .MuiTouchRipple-ripple': {
-                                transform: 'scale(1.9)',
-                            }
-                        },
-                        containedPrimary: {
-                            borderRadius: '9999px',
-                            paddingLeft: "16px", paddingRight: "16px",
-                            textTransform: "none"
-                        },
-                        containedSecondary: {
-                            borderRadius: '9999px',
-                            paddingLeft: "16px", paddingRight: "16px",
-                            textTransform: "none"
-                        }
-
-                    },
-                    variants: [
-                        {
-                            props: { variant: 'dialogPrimary' },
-                            style: {
-                                color: "#FFFFFF"
-                            }
-                        },
-                        {
-                            props: { variant: 'dialogSecondary', },
-                            style: {
-                                color: "rgb(255,255,255,0.7)"
-                            },
-                        },
-                    ],
-                },
+            shape: { borderRadius: 10 },
+            typography: {
+                fontFamily: '"Roboto", "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+                h6: { fontWeight: 600, letterSpacing: '-0.01em' },
+                subtitle1: { fontWeight: 500 },
+                subtitle2: { fontWeight: 500, letterSpacing: '0.01em' },
+                button: { fontWeight: 600, letterSpacing: '0.01em' },
+                caption: { letterSpacing: '0.02em' },
             },
-
+            components: sharedComponents(true),
             palette: {
                 mode: 'dark',
-                primary: {
-                    main: '#A770E4'// #6750A4"   // #5B5690  #60529A  #5C5694
+                primary: { main: '#A770E4' },
+                secondary: { main: '#FF6060' },
+                background: {
+                    default: '#16141d',
+                    paper: '#221f2c',
                 },
-                secondary: {
-                    main: "#FF6060"
+                text: {
+                    primary: 'rgba(255,255,255,0.92)',
+                    secondary: 'rgba(255,255,255,0.60)',
+                    disabled: 'rgba(255,255,255,0.35)',
+                },
+                divider: 'rgba(255,255,255,0.08)',
+                action: {
+                    hover: 'rgba(167,112,228,0.10)',
+                    selected: 'rgba(167,112,228,0.16)',
+                    focus: 'rgba(167,112,228,0.12)',
                 },
                 actionBar: {
                     main: '#130b22ff',
-                    contrastText: '#FFFFFF'
-                }
-
+                    contrastText: '#FFFFFF',
+                },
             },
-            mainBackground: "#222",
-            toolbarColor: '#222'
+            mainBackground: '#16141d',
+            toolbarColor: '#16141d',
         }
         :
         {
             cssVariables: true,
-            components: {
-                /* make the selection state for MuiListItemButtons a smidgen darker (light theme only) */
-                MuiListItemButton: {
-                    styleOverrides: {
-                        root: ({ theme }) => ({
-                            '&.Mui-selected': {
-                                backgroundColor: 'rgba(0, 0, 0, 0.2)', // Adjust for desired darkness
-                                '&:hover': {
-                                    backgroundColor: 'rgba(0, 0, 0, 0.25)', // Slightly darker on hover
-                                },
-                            },
-                        }),
-                    },
-                },
-                MuiButton: {
-                    styleOverrides: {
-                        root: {
-                            '& .MuiTouchRipple-root': {
-                                borderRadius: 'inherit',
-                            },
-                            '& .MuiTouchRipple-ripple': {
-                                transform: 'scale(1.9)!important',
-                            }
-                        },
-                        containedPrimary: {
-                            borderRadius: '9999px',
-                            paddingLeft: "16px", paddingRight: "16px",
-                            textTransform: "none"
-                        },
-                        containedSecondary: {
-                            borderRadius: '9999px',
-                            paddingLeft: "16px", paddingRight: "16px",
-                            textTransform: "none"
-                        }
-
-                    },
-                    variants: [
-                        {
-                            props: { variant: 'dialogPrimary' },
-                            style: {
-                                color: "rgb(0,0,0,0.87)"
-                            }
-                        },
-                        {
-                            props: { variant: 'dialogSecondary', },
-                            style: {
-                                color: "rgb(0,0,0,0.6)"
-                            },
-                        },
-                    ],
-                },
+            shape: { borderRadius: 10 },
+            typography: {
+                fontFamily: '"Roboto", "Inter", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+                h6: { fontWeight: 600, letterSpacing: '-0.01em' },
+                subtitle1: { fontWeight: 500 },
+                subtitle2: { fontWeight: 500, letterSpacing: '0.01em' },
+                button: { fontWeight: 600, letterSpacing: '0.01em' },
+                caption: { letterSpacing: '0.02em' },
             },
+            components: sharedComponents(false),
             palette: {
-                primary: {
-                    main: "#6750A4"   // #5B5690  #60529A  #5C5694
+                mode: 'light',
+                primary: { main: '#6750A4' },
+                secondary: { main: '#FF6060' },
+                background: {
+                    default: '#FAFAFA',
+                    paper: '#FFFFFF',
                 },
-                secondary: {
-                    main: "#FF6060"
+                text: {
+                    primary: 'rgba(0,0,0,0.87)',
+                    secondary: 'rgba(0,0,0,0.55)',
+                    disabled: 'rgba(0,0,0,0.30)',
+                },
+                divider: 'rgba(0,0,0,0.08)',
+                action: {
+                    hover: 'rgba(103,80,164,0.08)',
+                    selected: 'rgba(103,80,164,0.12)',
+                    focus: 'rgba(103,80,164,0.10)',
                 },
                 actionBar: {
                     main: '#130b22ff',
-                    contrastText: '#FFFFFF'
-                }
-
-
-
+                    contrastText: '#FFFFFF',
+                },
             },
-            mainBackground: "#FFFFFF",
-            toolbarColor: '#FFFFFF'
-
-
+            // Must equal palette.background.default: panels fill with mainBackground while the
+            // page behind them uses background.default, so any difference shows as banding.
+            mainBackground: '#FAFAFA',
+            toolbarColor: '#FAFAFA',
         }
 );
 

--- a/vite/src/pipedal/AppThemed.css
+++ b/vite/src/pipedal/AppThemed.css
@@ -58,3 +58,24 @@ img {
     user-select: none;
 }
 
+@keyframes ppLedPulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+}
+
+@keyframes ppSignalFlow {
+    to { stroke-dashoffset: -16; }
+}
+.ppSignalFlow {
+    stroke-dasharray: 4 4;
+    animation: ppSignalFlow 1.2s linear infinite;
+}
+
+/* The dashes stay, so an enabled path still reads differently from a bypassed one; only the
+   movement stops. The LED has its own rule, beside its emotion style in PedalboardView. */
+@media (prefers-reduced-motion: reduce) {
+    .ppSignalFlow {
+        animation: none;
+    }
+}
+

--- a/vite/src/pipedal/AppThemed.tsx
+++ b/vite/src/pipedal/AppThemed.tsx
@@ -91,18 +91,19 @@ const appStyles = ((theme: Theme) => (
             colorScheme: (isDarkMode() ? "dark" : "light")
         }),
         menuListItem: css({
-            color: "#FE8!important", //theme.palette.text.primary,
-            fill: "#FE8!important", //theme.palette.text.primary,
+            color: theme.palette.text.primary,
+            fill: theme.palette.text.primary,
         }),
         menuIcon: css({
-            fill: (theme.palette.text.primary + "!important"), //theme.palette.text.primary,
-            opacity: 0.6
+            fill: (theme.palette.text.primary + "!important"),
+            opacity: 0.85,
+            transition: 'opacity 150ms ease-out',
         }),
         toolBar: css({
-            color: "white"
+            color: theme.palette.text.primary,
         }),
         listSubheader: css({
-            backgroundImage: "linear-gradient(255,255,255,0.15),rgba(255,255,255,0.15)"
+            color: theme.palette.text.secondary,
         }),
         loadingContent: css({
             display: "block",
@@ -175,6 +176,13 @@ const appStyles = ((theme: Theme) => (
             textAlign: "start",
             zIndex: 2010
 
+        }),
+        modalScrim: css({
+            position: "absolute",
+            minHeight: "10em",
+            left: 0, top: 0, right: 0, bottom: 0,
+            opacity: 0.8,
+            background: theme.palette.background.default,
         }),
         loadingBox: css({
             display: "flex",
@@ -1110,17 +1118,7 @@ export
                         position: "absolute", top: 0, left: 0, right: 0, bottom: 0
                     }}
                     >
-                        <div style={{
-                            position: "absolute",
-                            minHeight: "10em",
-                            left: "0px",
-                            top: "0px",
-                            right: "0px",
-                            bottom: "0px",
-                            opacity: 0.8,
-                            background:
-                                isDarkMode() ? "#222" : "#EEE",
-                        }} />
+                        <div className={classes.modalScrim} />
                         <div style={{ flex: "2 2 3px", height: 20 }} >&nbsp;</div>
                         <div className={classes.errorMessageBox} style={{ position: "relative" }} >
                             <div style={{ fontSize: "30px", position: "absolute", left: 0, top: 3, color: "#A00" }}>
@@ -1150,18 +1148,7 @@ export
                     aria-describedby="reloading-modal-description"
                 >
                     <div style={{ display: "flex", flexFlow: "column nowrap", alignItems: "center" }}>
-                        <div style={{
-                            position: "absolute",
-                            minHeight: "10em",
-                            left: "0px",
-                            top: "0px",
-                            right: "0px",
-                            bottom: "0px",
-                            opacity: 0.8,
-                            background:
-                                isDarkMode() ? "#222" : "#EEE",
-
-                        }} />
+                        <div className={classes.modalScrim} />
                         <div className={classes.loadingBox}>
                             <div className={classes.loadingBoxItem}>
                                 <CircularProgress color="inherit" className={classes.loadingBoxItem} />

--- a/vite/src/pipedal/BankDialog.tsx
+++ b/vite/src/pipedal/BankDialog.tsx
@@ -22,6 +22,8 @@ import IconButtonEx from './IconButtonEx';
 import Typography from '@mui/material/Typography';
 import { PiPedalModel, PiPedalModelFactory } from './PiPedalModel';
 import { BankIndexEntry, BankIndex } from './Banks';
+import { isDarkMode } from './DarkMode';
+import { dialogActionBarBackgroundImage } from './ThemeSurfaces';
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
 import Slide, { SlideProps } from '@mui/material/Slide';
@@ -94,7 +96,8 @@ const styles = (theme: Theme) => createStyles({
     dialogActionBar: css({
         position: 'relative',
         top: 0, left: 0,
-        background: "black"
+        backgroundImage: dialogActionBarBackgroundImage(isDarkMode()),
+        color: '#FFFFFF',
     }),
     dialogTitle: css({
         marginLeft: theme.spacing(2),

--- a/vite/src/pipedal/ContentAlignment.tsx
+++ b/vite/src/pipedal/ContentAlignment.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Robin E.R. Davies
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import { ObservableProperty } from './ObservableProperty';
+
+// Horizontal placement of the pedal chain and of the plugin control panel. A browser-local
+// display preference, so it is stored in localStorage rather than in server settings.
+export enum ContentAlignment {
+    Start = "Start",
+    Center = "Center"
+};
+
+const CONTENT_ALIGNMENT_STORAGE_KEY = "com.twoplay.pipedal.content_alignment";
+const DEFAULT_CONTENT_ALIGNMENT = ContentAlignment.Center;
+
+function readStoredContentAlignment(): ContentAlignment {
+    switch (localStorage.getItem(CONTENT_ALIGNMENT_STORAGE_KEY)) {
+        case ContentAlignment.Start:
+            return ContentAlignment.Start;
+        case ContentAlignment.Center:
+            return ContentAlignment.Center;
+        default:
+            return DEFAULT_CONTENT_ALIGNMENT;
+    }
+}
+
+// Observed by the pedalboard and control views, so toggling re-lays them out without a reload.
+export const contentAlignmentProperty: ObservableProperty<ContentAlignment>
+    = new ObservableProperty<ContentAlignment>(readStoredContentAlignment());
+
+export function getContentAlignment(): ContentAlignment {
+    return contentAlignmentProperty.get();
+}
+
+export function setContentAlignment(value: ContentAlignment): void {
+    localStorage.setItem(CONTENT_ALIGNMENT_STORAGE_KEY, value);
+    contentAlignmentProperty.set(value);
+}

--- a/vite/src/pipedal/LoadPluginDialog.tsx
+++ b/vite/src/pipedal/LoadPluginDialog.tsx
@@ -50,6 +50,9 @@ import WithStyles, {withTheme} from './WithStyles';
 import { withStyles } from "tss-react/mui";
 import FilterListIcon from '@mui/icons-material/FilterList';
 import FilterListOffIcon from '@mui/icons-material/FilterListOff';
+import Chip from '@mui/material/Chip';
+import ViewListIcon from '@mui/icons-material/ViewList';
+import ViewModuleIcon from '@mui/icons-material/ViewModule';
 
 import { css } from '@emotion/react';
 
@@ -59,6 +62,27 @@ export type OkEventHandler = (pluginUri: string) => void;
 
 const NARROW_DISPLAY_THRESHOLD = 600;
 const FILTER_STORAGE_KEY = "com.twoplay.pipedal.load_dlg.filter";
+const VIEW_MODE_STORAGE_KEY = "com.twoplay.pipedal.load_dlg.view_mode";
+
+export type PluginViewMode = "grid" | "list";
+
+const ALPHABET_RAIL_WIDTH = 26;
+const ALPHABET_LETTERS = "#ABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
+const ALPHABET_RAIL_PADDING = 2;
+const ALPHABET_RAIL_FONT_SIZE = 11;
+const ALPHABET_RAIL_LINE_HEIGHT = "1.05";
+const ALPHABET_RAIL_ACTIVE_WEIGHT = 600;
+const ALPHABET_RAIL_INACTIVE_WEIGHT = 400;
+
+const PLUGIN_ICON_TILE_SIZE = 34;
+const PLUGIN_ICON_TILE_BORDER_RADIUS = 8;
+const PLUGIN_ICON_SIZE = 22;
+const PLUGIN_ICON_OPACITY = 0.92;
+
+function alphabetKeyOf(name: string): string {
+    const first = name.trim().charAt(0).toUpperCase();
+    return (first >= "A" && first <= "Z") ? first : "#";
+}
 
 
 
@@ -125,6 +149,12 @@ const pluginGridStyles = (theme: Theme) => createStyles({
         paddingLeft: 12, whiteSpace: "nowrap", textOverflow: "ellipsis"
 
     }),
+    listRow: css({
+        display: "flex", flexFlow: "row nowrap", alignItems: "center",
+        flex: "1 1 auto", width: "100%", minWidth: 0,
+        paddingLeft: 12, paddingRight: 8,
+        height: "100%",
+    }),
     favoriteDecoration: css({
         flex: "0 0 auto"
     }),
@@ -140,6 +170,13 @@ const pluginGridStyles = (theme: Theme) => createStyles({
     iconBorder: css({
         flex: "0 0 auto",
         paddingTop: "4px"
+    }),
+    iconTile: css({
+        width: PLUGIN_ICON_TILE_SIZE, height: PLUGIN_ICON_TILE_SIZE,
+        borderRadius: PLUGIN_ICON_TILE_BORDER_RADIUS,
+        display: "flex", alignItems: "center", justifyContent: "center",
+        background: theme.palette.action.hover,
+        border: `1px solid ${theme.palette.divider}`,
     }),
     label: css({
         width: "100%"
@@ -178,6 +215,7 @@ type PluginGridState = {
     grid_cell_width: number,
     grid_cell_columns: number,
     minimumItemWidth: number,
+    viewMode: PluginViewMode,
     favoritesList: FavoritesList,
     uiPlugins: UiPlugin[]
     //gridItems: UiPlugin[];
@@ -203,6 +241,8 @@ export const LoadPluginDialog =
                 if (persistedFilter) {
                     filterType_ = persistedFilter as PluginType;
                 }
+                const persistedViewMode = window.localStorage.getItem(VIEW_MODE_STORAGE_KEY);
+                const viewMode_: PluginViewMode = persistedViewMode === "list" ? "list" : "grid";
 
                 this.state = {
                     selected_uri: this.props.uri,
@@ -214,6 +254,7 @@ export const LoadPluginDialog =
                     grid_cell_width: this.getCellWidth(document.documentElement.clientWidth),
                     grid_cell_columns: this.getCellColumns(document.documentElement.clientWidth),
                     minimumItemWidth: props.minimumItemWidth ? props.minimumItemWidth : 220,
+                    viewMode: viewMode_,
                     favoritesList: this.model.favorites.get(),
                     uiPlugins: this.model.ui_plugins.get()
 
@@ -345,14 +386,23 @@ export const LoadPluginDialog =
             }
 
             onFilterChange(e: any) {
-                let filterValue = e.target.value as PluginType;
+                this.setFilterType(e.target.value as PluginType);
+            }
 
+            setFilterType(filterValue: PluginType): void {
                 window.localStorage.setItem(FILTER_STORAGE_KEY, filterValue as string);
 
                 this.requestScrollTo();
                 this.setState({
                     filterType: filterValue,
                 });
+            }
+
+            setViewMode(viewMode: PluginViewMode): void {
+                if (this.state.viewMode === viewMode) return;
+                window.localStorage.setItem(VIEW_MODE_STORAGE_KEY, viewMode);
+                this.requestScrollTo();
+                this.setState({ viewMode: viewMode });
             }
             onClearFilter(): void {
                 let value = PluginType.Plugin;
@@ -509,6 +559,97 @@ export const LoadPluginDialog =
                 return result;
 
             }
+
+            renderCategoryChips(): ReactNode {
+                const rootClass = this.model.plugin_classes.get();
+                const topLevel = rootClass.children;
+                const filterType = this.state.filterType;
+                const isAll = filterType === PluginType.Plugin;
+
+                const chipFor = (key: string, label: string, selected: boolean, value: PluginType) => (
+                    <Chip
+                        key={key}
+                        label={label}
+                        size="small"
+                        color={selected ? "primary" : "default"}
+                        variant={selected ? "filled" : "outlined"}
+                        onClick={() => { this.setFilterType(value); }}
+                        style={{ flex: "0 0 auto", fontWeight: selected ? 600 : 400 }}
+                    />
+                );
+
+                return (
+                    <div style={{
+                        flex: "0 0 auto",
+                        display: "flex", flexFlow: "row nowrap", alignItems: "center", gap: 6,
+                        overflowX: "auto", overflowY: "hidden",
+                        paddingLeft: 16, paddingRight: 16, paddingBottom: 8,
+                        scrollbarWidth: "none",
+                    }}>
+                        {chipFor("all", "All", isAll, PluginType.Plugin)}
+                        {topLevel.map((child: PluginClass) => {
+                            const selected = !isAll && (
+                                child.plugin_type === filterType
+                                || rootClass.is_type_of(child.plugin_type, filterType)
+                            );
+                            return chipFor(child.plugin_type as string, child.display_name, selected, child.plugin_type);
+                        })}
+                    </div>
+                );
+            }
+
+            // Resolves letters against the displayed array rather than computing offsets: favourites
+            // are score-boosted to the top by getFilteredPlugins, so it is not one sorted run.
+            buildAlphabetIndex(gridItems: UiPlugin[], columnCount: number): Map<string, number> {
+                const map = new Map<string, number>();
+                for (let i = 0; i < gridItems.length; ++i) {
+                    const key = alphabetKeyOf(gridItems[i].name);
+                    if (!map.has(key)) {
+                        map.set(key, Math.floor(i / columnCount));
+                    }
+                }
+                return map;
+            }
+
+            renderAlphabetRail(gridItems: UiPlugin[], columnCount: number): ReactNode {
+                const index = this.buildAlphabetIndex(gridItems, columnCount);
+                return (
+                    <div style={{
+                        flex: "0 0 auto", width: ALPHABET_RAIL_WIDTH,
+                        display: "flex", flexFlow: "column nowrap",
+                        alignItems: "stretch", justifyContent: "space-evenly",
+                        paddingTop: ALPHABET_RAIL_PADDING, paddingBottom: ALPHABET_RAIL_PADDING,
+                        userSelect: "none",
+                    }}>
+                        {ALPHABET_LETTERS.map((letter) => {
+                            const row = index.get(letter);
+                            const enabled = row !== undefined;
+                            return (
+                                <div
+                                    key={letter}
+                                    onClick={enabled ? () => { this.scrollToRow(row as number); } : undefined}
+                                    style={{
+                                        cursor: enabled ? "pointer" : "default",
+                                        textAlign: "center",
+                                        fontSize: ALPHABET_RAIL_FONT_SIZE,
+                                        lineHeight: ALPHABET_RAIL_LINE_HEIGHT,
+                                        fontWeight: enabled ? ALPHABET_RAIL_ACTIVE_WEIGHT : ALPHABET_RAIL_INACTIVE_WEIGHT,
+                                        color: enabled
+                                            ? this.props.theme.palette.text.secondary
+                                            : this.props.theme.palette.text.disabled,
+                                    }}
+                                >
+                                    {letter}
+                                </div>
+                            );
+                        })}
+                    </div>
+                );
+            }
+
+            scrollToRow(rowIndex: number): void {
+                this.gridRef?.scrollToItem({ rowIndex: rowIndex, align: "start" });
+            }
             getFilteredPlugins(plugins: UiPlugin[], searchString: string | null, filterType: PluginType | null, favoritesList: FavoritesList | null): UiPlugin[] {
                 try {
                     if (searchString === null) {
@@ -523,7 +664,7 @@ export const LoadPluginDialog =
 
                     let results: { score: number; plugin: UiPlugin }[] = [];
                     let searchFilter = new SearchFilter(searchString);
-                    let rootClass = this.model.plugin_classes.get();
+                    const rootClass = this.model.plugin_classes.get();
 
                     for (let i = 0; i < plugins.length; ++i) {
                         let plugin = plugins[i];
@@ -575,8 +716,10 @@ export const LoadPluginDialog =
             }
 
             private cachedGridItems: UiPlugin[] = []; // retained for the scrollTo callback.
+            private gridRef: FixedSizeGrid | null = null;
 
             handleScrollToCallback(element: FixedSizeGrid): void {
+                this.gridRef = element ?? null;
                 if (element) {
                     if (this.scrollToRequested) {
                         this.scrollToRequested = false;
@@ -643,6 +786,7 @@ export const LoadPluginDialog =
                 let value = gridItems[item];
 
                 const classes = withStyles.getClasses(this.props);
+                const isListView = this.state.viewMode === "list";
                 let isFavorite: boolean = this.state.favoritesList[value.uri] ?? false;
                 let pluginType = value.plugin_type;
                 if (value.uri === "http://two-play.com/plugins/toob-nam") {
@@ -657,30 +801,48 @@ export const LoadPluginDialog =
                     >
                         <ButtonBase className={classes.buttonBase} >
                             <SelectHoverBackground selected={value.uri === this.state.selected_uri} showHover={true} />
-                            <div className={classes.content}>
-                                <div className={classes.iconBorder} >
-                                    <PluginIcon pluginType={pluginType} size={24} opacity={0.6} />
+                            <div className={classes.content} style={isListView ? { alignItems: "center" } : undefined}>
+                                <div className={classes.iconBorder} style={isListView ? { paddingTop: 0 } : undefined}>
+                                    <div className={classes.iconTile}>
+                                        <PluginIcon pluginType={pluginType} size={PLUGIN_ICON_SIZE} opacity={PLUGIN_ICON_OPACITY} />
+                                    </div>
                                 </div>
-                                <div className={classes.content2}>
-                                    <div className={classes.label} style={{ display: "flex", flexFlow: "row nowrap", alignItems: "center" }} >
-
-                                        <Typography color="textPrimary" noWrap sx={{ display: "block", flex: "0 1 auto", }} >
+                                {isListView ? (
+                                    <div className={classes.listRow}>
+                                        <Typography color="textPrimary" noWrap sx={{ flex: "1 1 auto", minWidth: 0, fontWeight: 500 }} >
                                             {value.name}
                                         </Typography>
                                         {
                                             isFavorite && (
-                                                <div style={{ flex: "0 0 auto" }}>
-                                                    <StarIcon sx={{ color: "#C80", fontSize: 16, marginRight: "2px" }} />
-                                                </div>
+                                                <StarIcon sx={{ flex: "0 0 auto", color: "#C80", fontSize: 16, marginLeft: "4px" }} />
                                             )
                                         }
-
+                                        <Typography color="textSecondary" noWrap variant="body2" sx={{ flex: "0 0 auto", marginLeft: 2, textAlign: "right" }}>
+                                            {value.plugin_display_type}{this.stereo_indicator(value)}
+                                            {value.author_name !== "" ? "  ·  " + value.author_name : ""}
+                                        </Typography>
                                     </div>
-                                    <Typography color="textSecondary" noWrap>
-                                        {value.plugin_display_type} {this.stereo_indicator(value)}
+                                ) : (
+                                    <div className={classes.content2}>
+                                        <div className={classes.label} style={{ display: "flex", flexFlow: "row nowrap", alignItems: "center" }} >
 
-                                    </Typography>
-                                </div>
+                                            <Typography color="textPrimary" noWrap sx={{ display: "block", flex: "0 1 auto", fontWeight: 500 }} >
+                                                {value.name}
+                                            </Typography>
+                                            {
+                                                isFavorite && (
+                                                    <div style={{ flex: "0 0 auto", display: "flex", alignItems: "center" }}>
+                                                        <StarIcon sx={{ color: "#C80", fontSize: 16, marginLeft: "4px", marginRight: "2px" }} />
+                                                    </div>
+                                                )
+                                            }
+
+                                        </div>
+                                        <Typography color="textSecondary" noWrap variant="body2">
+                                            {value.plugin_display_type}{this.stereo_indicator(value)}
+                                        </Typography>
+                                    </div>
+                                )}
                                 <div className={classes.favoriteDecoration}>
 
                                 </div>
@@ -710,9 +872,18 @@ export const LoadPluginDialog =
                 if (this.state.client_width < 500) {
                     showSearchIcon = this.state.search_collapsed
                 }
-                let gridColumnCount = this.state.grid_cell_columns;
+                const isListView = this.state.viewMode === "list";
+                const gridColumnCount = isListView ? 1 : this.state.grid_cell_columns;
                 this.gridColumnCount = gridColumnCount;
+                // A search sorts by match score, not alphabetically, so the rail would jump to
+                // arbitrary rows.
+                const showAlphabetRail = this.state.search_string === "";
                 let isFavorite = this.state.favoritesList[this.state.selected_uri ?? ""];
+                // Not computed inside the AutoSizer callback: that has not run on the first pass, and the
+                // A-Z rail needs the same array.
+                const gridItems = this.getFilteredPlugins(
+                    this.state.uiPlugins, this.state.search_string, this.state.filterType, this.state.favoritesList);
+                this.cachedGridItems = gridItems;
                 return (
                     <React.Fragment>
                         <DialogEx tag="plugins"
@@ -790,6 +961,17 @@ export const LoadPluginDialog =
                                             />
                                         </div>
                                         <div style={{ flex: "0 0 auto" }} >
+                                            <IconButtonEx
+                                                tooltip={isListView ? "Grid view" : "List view"}
+                                                onClick={() => { this.setViewMode(isListView ? "grid" : "list"); }}>
+                                                {isListView ? (
+                                                    <ViewModuleIcon fontSize='small' style={{ opacity: 0.75 }} />
+                                                ) : (
+                                                    <ViewListIcon fontSize='small' style={{ opacity: 0.75 }} />
+                                                )}
+                                            </IconButtonEx>
+                                        </div>
+                                        <div style={{ flex: "0 0 auto" }} >
                                             <IconButtonEx tooltip="Clear Filter" onClick={() => { this.onClearFilter(); }}>
                                                 {this.state.filterType === PluginType.Plugin ? (
                                                     <FilterListIcon fontSize='small' style={{ opacity: 0.75 }} />
@@ -811,11 +993,14 @@ export const LoadPluginDialog =
                                         </div>
                                     </div>
                                 </DialogTitle>
+                                {this.renderCategoryChips()}
                                 <DialogContent dividers style={{
                                     height: "100px",
                                     padding: 8,
                                     flex: "1 1 100px",
+                                    display: "flex", flexFlow: "row nowrap",
                                 }} >
+                                    <div style={{ flex: "1 1 auto", minWidth: 0, height: "100%", position: "relative" }}>
                                     <AutoSizer>
                                         {(arg: any) => {
                                             if ((!arg.width) || (!arg.height)) {
@@ -823,9 +1008,6 @@ export const LoadPluginDialog =
                                             }
                                             let width = arg.width ?? 1;
                                             let height = arg.height ?? 1;
-                                            let gridItems = this.getFilteredPlugins(
-                                                this.state.uiPlugins, this.state.search_string, this.state.filterType, this.state.favoritesList);
-                                            this.cachedGridItems = gridItems;
 
                                             let scrollRef = (grid: FixedSizeGrid) => { this.handleScrollToCallback(grid); }
 
@@ -863,6 +1045,8 @@ export const LoadPluginDialog =
                                         }
                                         }
                                     </AutoSizer>
+                                    </div>
+                                    {showAlphabetRail && this.renderAlphabetRail(gridItems, gridColumnCount)}
                                 </DialogContent>
                                 {(this.state.client_width >= NARROW_DISPLAY_THRESHOLD) ? (
                                     <DialogActions style={{ flex: "0 0 auto" }} >

--- a/vite/src/pipedal/MainPage.tsx
+++ b/vite/src/pipedal/MainPage.tsx
@@ -51,13 +51,8 @@ import PluginPresetSelector from './PluginPresetSelector';
 import OldDeleteIcon from "./svg/old_delete_outline_24dp.svg?react";
 import MidiIcon from "./svg/ic_midi.svg?react";
 import { isDarkMode } from './DarkMode';
-import Snapshot0Icon from "./svg/snapshot_0.svg?react";
-import Snapshot1Icon from "./svg/snapshot_1.svg?react";
-import Snapshot2Icon from "./svg/snapshot_2.svg?react";
-import Snapshot3Icon from "./svg/snapshot_3.svg?react";
-import Snapshot4Icon from "./svg/snapshot_4.svg?react";
-import Snapshot5Icon from "./svg/snapshot_5.svg?react";
-import Snapshot6Icon from "./svg/snapshot_6.svg?react";
+import { TOOLBAR_ICON_OPACITY } from './ThemeSurfaces';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 import ModUiIcon from './svg/mod_ui.svg?react';
 import PipedalUiIcon from './svg/pp_ui.svg?react';
 
@@ -72,6 +67,17 @@ const SHOW_ICON_THRESHHOLD = 475;
 const DISPLAY_AUTHOR_THRESHHOLD = 750;
 const DISPLAY_AUTHOR_SPLIT_THRESHOLD = 500;
 const HORIZONTAL_CONTROL_SCROLL_HEIGHT_BREAK = 500;
+
+const TOOLBAR_ICON_SIZE = 24;
+const SNAPSHOT_ICON_FONT_SIZE = 22;
+const SNAPSHOT_BADGE_SIZE = 13;
+const SNAPSHOT_BADGE_BOTTOM = -3;
+const SNAPSHOT_BADGE_RIGHT = -6;
+const SNAPSHOT_BADGE_PADDING = '0 3px';
+const SNAPSHOT_BADGE_FONT_SIZE = 9;
+const SNAPSHOT_BADGE_FONT_WEIGHT = 700;
+const SNAPSHOT_BADGE_TEXT_COLOR = '#FFF';
+const SNAPSHOT_BADGE_OUTLINE_WIDTH = 1.5;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 // const HORIZONTAL_LAYOUT_MQ = "@media (max-height: " + HORIZONTAL_CONTROL_SCROLL_HEIGHT_BREAK + "px)";
@@ -91,24 +97,27 @@ const styles = ({ palette }: Theme) => {
             flex: "1 1 1px", overflow: "auto"
         }),
         separator: css({
-            width: "100%", height: "1px", background: "#888", opacity: "0.5",
+            width: "100%", height: "1px",
+            background: palette.divider,
             flex: "0 0 1px"
         }),
 
         controlToolBar: css({
             flex: "0 0 auto", width: "100%", height: 48
         }),
+        // These three panels share one continuous surface: tinting them individually bands the
+        // page into mismatched greys. `separator` already divides the zones.
         splitControlBar: css({
-            flex: "0 0 64px", width: "100%", paddingLeft: 24, paddingRight: 16, paddingBottom: 16
+            flex: "0 0 64px", width: "100%", paddingLeft: 24, paddingRight: 16, paddingBottom: 16,
         }),
         controlContent: css({
-            flex: "1 1 auto", width: "100%", overflowY: "hidden", minHeight: 185
+            flex: "1 1 auto", width: "100%", overflowY: "hidden", minHeight: 185,
         }),
         controlContentSmall: css({
             flex: "0 0 162px", width: "100%", height: 162, overflowY: "hidden",
         }),
-        title: css({ fontSize: "1.1rem", fontWeight: 700, marginRight: 8, textOverflow: "ellipsis", whiteSpace: "nowrap", opacity: 0.75 }),
-        author: css({ fontWeight: 500, fontSize: "0.8rem", marginRight: 8, textOverflow: "ellipsis", whiteSpace: "nowrap", opacity: 0.75 })
+        title: css({ fontSize: "1.05rem", fontWeight: 700, marginRight: 8, textOverflow: "ellipsis", whiteSpace: "nowrap", letterSpacing: '-0.01em', color: palette.text.primary }),
+        author: css({ fontWeight: 500, fontSize: "0.78rem", marginRight: 8, textOverflow: "ellipsis", whiteSpace: "nowrap", color: palette.text.secondary })
     }
 };
 
@@ -564,9 +573,9 @@ export const MainPage =
                                             size="large">
                                             {(!this.state.showModUi || !canShowModUi) ?
                                                 (
-                                                    <ModUiIcon style={{ height: 24, width: 24, fill: this.props.theme.palette.text.primary, opacity: 0.6 }} />
+                                                    <ModUiIcon style={{ height: TOOLBAR_ICON_SIZE, width: TOOLBAR_ICON_SIZE, fill: this.props.theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
                                                 ) : (
-                                                    <PipedalUiIcon style={{ height: 24, width: 24, fill: this.props.theme.palette.text.primary, opacity: 0.6 }} />
+                                                    <PipedalUiIcon style={{ height: TOOLBAR_ICON_SIZE, width: TOOLBAR_ICON_SIZE, fill: this.props.theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
                                                 )
                                             }
                                         </IconButtonEx>
@@ -579,24 +588,34 @@ export const MainPage =
                     }
                 }
 
-                snapshotIcon(theme: Theme, snapshotNumber: number) {
-                    switch (snapshotNumber + 1) {
-                        case 0:
-                        default:
-                            return (<Snapshot0Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 1:
-                            return (<Snapshot1Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 2:
-                            return (<Snapshot2Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 3:
-                            return (<Snapshot3Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 4:
-                            return (<Snapshot4Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 5:
-                            return (<Snapshot5Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                        case 6:
-                            return (<Snapshot6Icon style={{ height: 24, width: 24, fill: theme.palette.text.primary, opacity: 0.6 }} />);
-                    }
+                snapshotButton(theme: Theme, snapshotNumber: number) {
+                    const hasSnapshot = snapshotNumber >= 0;
+                    return (
+                        <div style={{
+                            position: 'relative', display: 'inline-flex',
+                            alignItems: 'center', justifyContent: 'center',
+                            width: TOOLBAR_ICON_SIZE, height: TOOLBAR_ICON_SIZE
+                        }}>
+                            <PhotoCameraIcon style={{ fontSize: SNAPSHOT_ICON_FONT_SIZE, color: theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
+                            {hasSnapshot && (
+                                <span style={{
+                                    position: 'absolute',
+                                    bottom: SNAPSHOT_BADGE_BOTTOM, right: SNAPSHOT_BADGE_RIGHT,
+                                    minWidth: SNAPSHOT_BADGE_SIZE, height: SNAPSHOT_BADGE_SIZE,
+                                    borderRadius: SNAPSHOT_BADGE_SIZE / 2,
+                                    padding: SNAPSHOT_BADGE_PADDING,
+                                    background: theme.palette.primary.main,
+                                    color: SNAPSHOT_BADGE_TEXT_COLOR,
+                                    fontSize: SNAPSHOT_BADGE_FONT_SIZE,
+                                    fontWeight: SNAPSHOT_BADGE_FONT_WEIGHT,
+                                    lineHeight: `${SNAPSHOT_BADGE_SIZE}px`,
+                                    textAlign: 'center',
+                                    boxShadow: `0 0 0 ${SNAPSHOT_BADGE_OUTLINE_WIDTH}px ${theme.palette.background.default}`,
+                                    fontFamily: 'inherit',
+                                }}>{snapshotNumber + 1}</span>
+                            )}
+                        </div>
+                    );
                 }
 
                 canShowModUi(pedalboardItem: PedalboardItem): boolean {
@@ -678,7 +697,7 @@ export const MainPage =
                                 }} >
                                     <div style={{ flex: "0 0 auto", width: this.state.splitControlBar ? undefined : 60 }} >
                                         <div style={{ display: bypassVisible ? "block" : "none", width: this.state.splitControlBar ? undefined : 60 }} >
-                                            <ToolTipEx title="Bypass"
+                                            <ToolTipEx title={bypassChecked ? "Active (click to bypass)" : "Bypassed (click to activate)"}
                                             >
                                                 <Switch color="secondary" checked={bypassChecked} onChange={this.handleEnableCurrentItemChanged} />
                                             </ToolTipEx>
@@ -700,7 +719,7 @@ export const MainPage =
 
                                             <div style={{ flex: "0 0 auto", display: (canInsert || canAppend) ? "block" : "none" }}>
                                                 <IconButtonEx tooltip="Add pedal slot" onClick={(e) => { this.onAddClick(e) }} size="large">
-                                                    <AddIcon style={{ height: 24, width: 24, fill: this.props.theme.palette.text.primary, opacity: 0.6 }} />
+                                                    <AddIcon style={{ height: TOOLBAR_ICON_SIZE, width: TOOLBAR_ICON_SIZE, fill: this.props.theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
                                                 </IconButtonEx>
                                                 <Menu
                                                     id="add-menu"
@@ -721,7 +740,7 @@ export const MainPage =
                                                 <IconButtonEx tooltip="Delete pedal"
                                                     onClick={() => { this.onDeletePedal(pedalboardItem?.instanceId ?? -1) }}
                                                     size="large">
-                                                    <OldDeleteIcon style={{ height: 24, width: 24, fill: this.props.theme.palette.text.primary, opacity: 0.6 }} />
+                                                    <OldDeleteIcon style={{ height: TOOLBAR_ICON_SIZE, width: TOOLBAR_ICON_SIZE, fill: this.props.theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
                                                 </IconButtonEx>
                                             </div>
                                             <div style={{ flex: "0 0 auto" }}>
@@ -735,24 +754,25 @@ export const MainPage =
                                                     startIcon={<InputIcon />}
                                                     style={{
                                                         textTransform: "none",
-                                                        background: (isDarkMode() ? "#6750A4" : undefined)
+                                                        padding: this.state.canDisplayPluginIcon ? undefined : '6px 10px',
+                                                        minWidth: 0,
                                                     }}
                                                 >
-                                                    Load
+                                                    {this.state.canDisplayPluginIcon ? "Load" : ""}
                                                 </ButtonEx>
                                             </div>
                                             <div style={{ flex: "0 0 auto" }}>
                                                 <IconButtonEx tooltip="MIDI bindings"
                                                     onClick={(e) => { this.handleMidiConfiguration(instanceId); }}
                                                     size="large">
-                                                    <MidiIcon style={{ height: 24, width: 24, fill: this.props.theme.palette.text.primary, opacity: 0.6 }} />
+                                                    <MidiIcon style={{ height: TOOLBAR_ICON_SIZE, width: TOOLBAR_ICON_SIZE, fill: this.props.theme.palette.text.primary, opacity: TOOLBAR_ICON_OPACITY }} />
                                                 </IconButtonEx>
                                             </div>
                                             <div style={{ flex: "0 0 auto" }}>
                                                 <IconButtonEx tooltip="Snapshots"
                                                     onClick={(e) => { this.setState({ snapshotDialogOpen: true }); }}
                                                     size="large">
-                                                    {this.snapshotIcon(this.props.theme, this.state.selectedSnapshot)}
+                                                    {this.snapshotButton(this.props.theme, this.state.selectedSnapshot)}
                                                 </IconButtonEx>
                                             </div>
                                         </div>

--- a/vite/src/pipedal/PedalboardView.tsx
+++ b/vite/src/pipedal/PedalboardView.tsx
@@ -38,6 +38,7 @@ import Rect from './Rect';
 import { PiPedalStateError } from './PiPedalError';
 import Utility from './Utility';
 import { isDarkMode } from './DarkMode';
+import { ContentAlignment, contentAlignmentProperty, getContentAlignment } from './ContentAlignment';
 import {
     Pedalboard, PedalboardItem, PedalboardSplitItem, SplitType
 } from './Pedalboard';
@@ -53,8 +54,8 @@ const END_CONTROL = Pedalboard.END_CONTROL_ID;
 const START_PEDALBOARD_ITEM_URI = Pedalboard.START_PEDALBOARD_ITEM_URI;
 const END_PEDALBOARD_ITEM_URI = Pedalboard.END_PEDALBOARD_ITEM_URI;
 
-const ENABLED_CONNECTOR_COLOR = isDarkMode() ? "#CCC" : "#666";
-const DISABLED_CONNECTOR_COLOR = isDarkMode() ? "#666" : "#CCC";
+const ENABLED_CONNECTOR_COLOR = isDarkMode() ? "rgba(220,220,235,0.85)" : "rgba(80,70,95,0.70)";
+const DISABLED_CONNECTOR_COLOR = isDarkMode() ? "rgba(120,120,140,0.45)" : "rgba(170,170,185,0.60)";
 
 
 
@@ -63,6 +64,15 @@ const CELL_HEIGHT: number = 64;
 const FRAME_SIZE: number = 36;
 
 const STROKE_WIDTH = 3;
+
+const PEDAL_FRAME_BORDER_RADIUS = 10;
+
+const ACTIVE_LED_SIZE = 5;
+const ACTIVE_LED_INSET = 4;
+
+const COLOR_STRIP_HEIGHT = 3;
+const COLOR_STRIP_OPACITY = 0.85;
+const COLOR_STRIP_BORDER_RADIUS = PEDAL_FRAME_BORDER_RADIUS - 1;
 const STEREO_STROKE_WIDTH = 6;
 
 
@@ -159,7 +169,9 @@ const pedalboardStyles = (theme: Theme) => createStyles({
         width: FRAME_SIZE,
         height: FRAME_SIZE,
         padding: 0,
-        borderRadius: 8
+        borderRadius: 12,
+        transition: 'transform 180ms ease-out',
+        '&:active': { transform: 'scale(0.95)' },
     }),
 
     iconFrame: css({
@@ -168,16 +180,22 @@ const pedalboardStyles = (theme: Theme) => createStyles({
         alignItems: "center",
         justifyContent: "center",
         position: "relative",
-        background: theme.palette.background.paper,
+        background: isDarkMode()
+            ? `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`
+            : `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
 
         width: FRAME_SIZE,
         height: FRAME_SIZE,
-        borderColor: "#777",
-        borderWidth: 2,
+        borderColor: theme.palette.divider,
+        borderWidth: 1,
         borderStyle: "solid",
         overflow: "hidden",
         padding: 0,
-        borderRadius: 8
+        borderRadius: PEDAL_FRAME_BORDER_RADIUS,
+        boxShadow: isDarkMode()
+            ? '0 2px 4px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06)'
+            : '0 1px 3px rgba(0,0,0,0.10), inset 0 1px 0 rgba(255,255,255,0.65)',
+        transition: 'box-shadow 200ms ease-out, border-color 200ms ease-out',
     }),
     selectedIconFrame: css({
 
@@ -185,15 +203,20 @@ const pedalboardStyles = (theme: Theme) => createStyles({
         alignItems: "center",
         justifyContent: "center",
         position: "relative",
-        background: theme.palette.background.paper,
+        background: isDarkMode()
+            ? `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`
+            : `linear-gradient(180deg, ${theme.palette.background.paper} 0%, ${theme.palette.background.default} 100%)`,
         width: FRAME_SIZE,
         height: FRAME_SIZE,
         borderColor: theme.palette.primary.main,
-        borderWidth: "2.0px",
+        borderWidth: "1px",
         borderStyle: "solid",
         overflow: "hidden",
-        borderRadius: 8,
-        boxShadow: "0 0 6px 0px " + theme.palette.primary.main + "C0"
+        borderRadius: PEDAL_FRAME_BORDER_RADIUS,
+        boxShadow: isDarkMode()
+            ? `0 0 0 1px ${theme.palette.primary.main}, 0 0 14px ${theme.palette.primary.main}66, 0 2px 6px rgba(0,0,0,0.45), inset 0 1px 0 rgba(255,255,255,0.06)`
+            : `0 0 0 1px ${theme.palette.primary.main}, 0 0 14px ${theme.palette.primary.main}40, 0 2px 6px rgba(0,0,0,0.10), inset 0 1px 0 rgba(255,255,255,0.65)`,
+        transition: 'box-shadow 200ms ease-out, border-color 200ms ease-out',
     }),
     borderlessIconFrame: css({
 
@@ -204,9 +227,45 @@ const pedalboardStyles = (theme: Theme) => createStyles({
         background: "transparent",
         width: FRAME_SIZE,
         height: FRAME_SIZE,
-        border: "0px #666 solid",
-        borderRadius: 8,
+        border: "0px solid transparent",
+        borderRadius: PEDAL_FRAME_BORDER_RADIUS,
         overflow: "hidden",
+    }),
+
+    emptyIconFrame: css({
+
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        position: "relative",
+        background: 'transparent',
+        width: FRAME_SIZE,
+        height: FRAME_SIZE,
+        borderColor: isDarkMode() ? 'rgba(255,255,255,0.10)' : 'rgba(0,0,0,0.10)',
+        borderWidth: 1,
+        borderStyle: "dashed",
+        overflow: "hidden",
+        padding: 0,
+        borderRadius: PEDAL_FRAME_BORDER_RADIUS,
+        transition: 'border-color 200ms ease-out, background-color 200ms ease-out',
+    }),
+
+    activeLed: css({
+        position: 'absolute',
+        top: ACTIVE_LED_INSET,
+        right: ACTIVE_LED_INSET,
+        width: ACTIVE_LED_SIZE,
+        height: ACTIVE_LED_SIZE,
+        borderRadius: '50%',
+        background: theme.palette.primary.main,
+        boxShadow: `0 0 4px ${theme.palette.primary.main}, 0 0 1px ${theme.palette.primary.main}`,
+        zIndex: 2,
+        pointerEvents: 'none',
+        animation: 'ppLedPulse 2.4s ease-in-out infinite',
+        // Paired with the .ppSignalFlow rule in AppThemed.css.
+        '@media (prefers-reduced-motion: reduce)': {
+            animation: 'none',
+        },
     }),
 
     pedalIcon: css({
@@ -252,6 +311,7 @@ interface LayoutSize {
 
 type PedalboardState = {
     pedalboard?: Pedalboard;
+    contentAlignment: ContentAlignment;
 };
 
 const EMPTY_PEDALS: PedalLayout[] = [];
@@ -449,8 +509,10 @@ const PedalboardView =
                     if (!props.selectedId) props.selectedId = -1;
                     this.state = {
                         pedalboard: this.model.pedalboard.get(),
+                        contentAlignment: getContentAlignment(),
                     };
                     this.onPedalboardChanged = this.onPedalboardChanged.bind(this);
+                    this.onContentAlignmentChanged = this.onContentAlignmentChanged.bind(this);
                     this.frameRef = React.createRef();
                     this.scrollRef = React.createRef();
                     this.handleTouchStart = this.handleTouchStart.bind(this);
@@ -628,14 +690,20 @@ const PedalboardView =
                     });
                 }
 
+                onContentAlignmentChanged(value: ContentAlignment) {
+                    this.setState({ contentAlignment: value });
+                }
+
                 componentDidMount() {
                     this.scrollRef.current!.addEventListener("touchstart", this.handleTouchStart, { passive: false });
                     this.model.pedalboard.addOnChangedHandler(this.onPedalboardChanged);
+                    contentAlignmentProperty.addOnChangedHandler(this.onContentAlignmentChanged);
 
                 }
                 componentWillUnmount() {
                     this.scrollRef.current!.removeEventListener("touchstart", this.handleTouchStart);
                     this.model.pedalboard.removeOnChangedHandler(this.onPedalboardChanged);
+                    contentAlignmentProperty.removeOnChangedHandler(this.onContentAlignmentChanged);
                 }
 
                 offsetLayout_(layoutItems: PedalLayout[], offset: number): void {
@@ -854,14 +922,16 @@ const PedalboardView =
 
                     if (numberOfOutputs === 2) {
                         output.push((
-                            <path key={this.renderKey++} d={svgPath} stroke={color} strokeWidth={SVG_STEREO_STROKE_WIDTH} />
+                            <path key={this.renderKey++} d={svgPath} stroke={color} strokeWidth={SVG_STEREO_STROKE_WIDTH}
+                                className={enabled ? 'ppSignalFlow' : undefined} />
                         ));
                         output.push((
                             <path key={this.renderKey++} d={svgPath} stroke={stereoCenterColor} strokeWidth={SVG_STROKE_WIDTH} />
                         ));
                     } else if (numberOfOutputs === 1) {
                         output.push((
-                            <path key={this.renderKey++} d={svgPath} stroke={color} strokeWidth={SVG_STROKE_WIDTH} />
+                            <path key={this.renderKey++} d={svgPath} stroke={color} strokeWidth={SVG_STROKE_WIDTH}
+                                className={enabled ? 'ppSignalFlow' : undefined} />
                         ));
                     } else {
                         output.push((
@@ -1077,18 +1147,22 @@ const PedalboardView =
                 )
                     : ReactNode {
                     const classes = withStyles.getClasses(this.props);
+                    const isEmpty = iconType === PluginType.None;
                     let frameStyle = classes.iconFrame;
                     if (!hasBorder) {
                         frameStyle = classes.borderlessIconFrame;
-                    } else {
-                        if (instanceId === this.props.selectedId) {
-                            frameStyle = classes.selectedIconFrame;
-                        }
+                    } else if (isEmpty) {
+                        frameStyle = classes.emptyIconFrame;
+                    } else if (instanceId === this.props.selectedId) {
+                        frameStyle = classes.selectedIconFrame;
                     }
+                    const showLed = hasBorder && !isEmpty && enabled && !pluginNotFound;
+                    const stripColor = (hasBorder && !isEmpty) ? getIconColor(iconColor) : undefined;
+                    const isAmp = iconType === PluginType.AmplifierPlugin;
 
                     return (
                         <div style={{ width: "100%", height: "100%" }}>
-                            <ButtonBase className={classes.pedalButton} 
+                            <ButtonBase className={classes.pedalButton}
                                 onClick={(e) => { this.onItemClick(e, instanceId); }}
                                 onDoubleClick={(e: SyntheticEvent) => { this.onItemDoubleClick(e, instanceId); }}
                                 onContextMenu={(e: SyntheticEvent) => { this.onItemLongClick(e, instanceId); }}
@@ -1099,6 +1173,29 @@ const PedalboardView =
                                         clipChildren={false}
                                     >
                                     </SelectHoverBackground>
+                                    {showLed && <span className={classes.activeLed} />}
+                                    {stripColor && (
+                                        <div style={{
+                                            position: 'absolute', top: 0, left: 0, right: 0,
+                                            height: COLOR_STRIP_HEIGHT,
+                                            background: stripColor,
+                                            opacity: COLOR_STRIP_OPACITY,
+                                            borderTopLeftRadius: COLOR_STRIP_BORDER_RADIUS,
+                                            borderTopRightRadius: COLOR_STRIP_BORDER_RADIUS,
+                                            zIndex: 1,
+                                            pointerEvents: 'none',
+                                        }} />
+                                    )}
+                                    {isAmp && (
+                                        <div style={{
+                                            position: 'absolute', inset: 0,
+                                            background: isDarkMode()
+                                                ? 'repeating-linear-gradient(90deg, rgba(255,255,255,0.025) 0px, rgba(255,255,255,0.025) 1px, rgba(255,255,255,0.055) 1px, rgba(255,255,255,0.055) 2px)'
+                                                : 'repeating-linear-gradient(90deg, rgba(0,0,0,0.025) 0px, rgba(0,0,0,0.025) 1px, rgba(0,0,0,0.05) 1px, rgba(0,0,0,0.05) 2px)',
+                                            pointerEvents: 'none',
+                                            zIndex: 0,
+                                        }} />
+                                    )}
                                 </div>
                                 <Draggable draggable={draggable && (this.props.enableStructureEditing)} getScrollContainer={() => this.getScrollContainer()}
                                     onDragEnd={(x, y) => { this.onDragEnd(instanceId, x, y) }}
@@ -1146,7 +1243,7 @@ const PedalboardView =
                         <div key="connectors" style={{ width: layoutSize.width, height: layoutSize.height, overflow: "hidden" }}>
                             <svg width={layoutSize.width} height={layoutSize.height}
                                 xmlns="http://www.w3.org/2000/svg" viewBox={"0 0 " + layoutSize.width + " " + layoutSize.height}>
-                                <g fill="none">
+                                <g fill="none" strokeLinecap="round" strokeLinejoin="round">
                                     {
                                         outputs
                                     }
@@ -1387,12 +1484,18 @@ const PedalboardView =
 
                     this.currentLayout = layoutChain; // save for mouse processing &c.
 
+                    const centerContent = this.state.contentAlignment === ContentAlignment.Center;
+
                     return (
                         <div className={classes.scrollContainer} ref={this.scrollRef}
                         >
                             <div className={classes.container} ref={this.frameRef}
                                 style={{
                                     width: layoutSize.width, height: layoutSize.height,
+                                    // Auto margins, not justify-content on the scroll parent: they collapse to zero once the
+                                    // chain outgrows the viewport, which keeps the overflowing left edge reachable.
+                                    marginLeft: centerContent ? "auto" : undefined,
+                                    marginRight: centerContent ? "auto" : undefined,
                                 }} >
                                 {this.renderChain(layoutChain, layoutSize)}
                             </div>

--- a/vite/src/pipedal/PluginControlView.tsx
+++ b/vite/src/pipedal/PluginControlView.tsx
@@ -34,6 +34,7 @@ import { midiChannelBindingControlFeatureEnabled } from './MidiChannelBinding';
 
 import { withStyles } from "tss-react/mui";
 import { PiPedalModel, PiPedalModelFactory } from './PiPedalModel';
+import { ContentAlignment, contentAlignmentProperty, getContentAlignment } from './ContentAlignment';
 import { UiPlugin, UiControl, UiFileProperty, UiFrequencyPlot, ScalePoint } from './Lv2Plugin';
 import {
     Pedalboard, PedalboardItem, ControlValue
@@ -62,6 +63,9 @@ export const StandardItemSize = { width: 80, height: 110 };
 
 
 const LANDSCAPE_HEIGHT_BREAK = 500;
+
+const END_SPACER_SIZE = 40;
+const CENTERED_JUSTIFY_CONTENT = "center";
 
 
 export interface ICustomizationHost {
@@ -378,7 +382,8 @@ type PluginControlViewState = {
     dialogFileValue: string,
     modGuiContentReady: boolean,
     showModGuiZoomed: boolean,
-    sidechainDialogOpen: boolean
+    sidechainDialogOpen: boolean,
+    contentAlignment: ContentAlignment
 };
 
 
@@ -401,12 +406,14 @@ const PluginControlView =
                     dialogFileValue: "",
                     modGuiContentReady: false,
                     showModGuiZoomed: false,
-                    sidechainDialogOpen: false
+                    sidechainDialogOpen: false,
+                    contentAlignment: getContentAlignment()
 
                 }
                 this.onPedalboardChanged = this.onPedalboardChanged.bind(this);
                 this.onControlValueChanged = this.onControlValueChanged.bind(this);
                 this.onPreviewChange = this.onPreviewChange.bind(this);
+                this.onContentAlignmentChanged = this.onContentAlignmentChanged.bind(this);
             }
             // unmonitorPort: (handle: MonitorPortHandle) => void;
             // onValueChanged: (instanceId: number, symbol: string, value: number) => void;
@@ -437,12 +444,18 @@ const PluginControlView =
             }
 
 
+            onContentAlignmentChanged(value: ContentAlignment) {
+                this.setState({ contentAlignment: value });
+            }
+
             componentDidMount() {
                 super.componentDidMount();
                 this.model.pedalboard.addOnChangedHandler(this.onPedalboardChanged);
+                contentAlignmentProperty.addOnChangedHandler(this.onContentAlignmentChanged);
             }
             componentWillUnmount() {
                 this.model.pedalboard.removeOnChangedHandler(this.onPedalboardChanged);
+                contentAlignmentProperty.removeOnChangedHandler(this.onContentAlignmentChanged);
                 super.componentWillUnmount();
             }
 
@@ -1005,6 +1018,18 @@ const PluginControlView =
                     gridClass = classes.noScrollGrid;
                     scrollClass = classes.frameScrollNone;
                 }
+                // The wrapping grid fills the width, so justify-content centres it. The landscape grid is
+                // fit-content in a scroller, so auto margins: they collapse once it outgrows the viewport.
+                const centerContent = this.state.contentAlignment === ContentAlignment.Center
+                    && !this.fullScreen();
+                let gridAlignmentStyle: React.CSSProperties = {};
+                if (centerContent) {
+                    if (this.state.landscapeGrid) {
+                        gridAlignmentStyle = { marginLeft: "auto", marginRight: "auto" };
+                    } else {
+                        gridAlignmentStyle = { justifyContent: CENTERED_JUSTIFY_CONTENT };
+                    }
+                }
                 let controlNodes: ControlNodes;
 
                 controlNodes = this.getStandardControlNodes(plugin, controlValues);
@@ -1025,13 +1050,14 @@ const PluginControlView =
                 }
                 return (
                     <div className={scrollClass}>
-                        <div className={gridClass}  >
+                        <div className={gridClass} style={gridAlignmentStyle} >
                             {
                                 nodes
                             }
-                            {/* Extra space to allow scrolling right to the end in lascape especially */}
-                            {!this.fullScreen() && (
-                                <div style={{ flex: "0 0 40px", width: 40, height: 40 }} />
+                            {/* Extra space to allow scrolling right to the end in lascape especially. Omitted for a
+                                centred wrapping grid, which does not scroll and would sit off-centre by half its width. */}
+                            {!this.fullScreen() && !(centerContent && !this.state.landscapeGrid) && (
+                                <div style={{ flex: `0 0 ${END_SPACER_SIZE}px`, width: END_SPACER_SIZE, height: END_SPACER_SIZE }} />
                             )}
                             {
                                 (!this.state.landscapeGrid) && (!this.fullScreen()) && (

--- a/vite/src/pipedal/PluginPresetsDialog.tsx
+++ b/vite/src/pipedal/PluginPresetsDialog.tsx
@@ -21,6 +21,8 @@ import React, { SyntheticEvent,Component } from 'react';
 import IconButtonEx from './IconButtonEx';
 import Typography from '@mui/material/Typography';
 import { PiPedalModel, PiPedalModelFactory  } from './PiPedalModel';
+import { isDarkMode } from './DarkMode';
+import { dialogActionBarBackgroundImage } from './ThemeSurfaces';
 import Button from "@mui/material/Button";
 import ButtonBase from "@mui/material/ButtonBase";
 import DialogEx from './DialogEx';
@@ -95,7 +97,8 @@ const styles = (theme: Theme) => createStyles({
     dialogActionBar: css({
         position: 'relative',
         top: 0, left: 0,
-        background: "black"
+        backgroundImage: dialogActionBarBackgroundImage(isDarkMode()),
+        color: '#FFFFFF',
     }),
     dialogTitle: css({
         marginLeft: theme.spacing(2),

--- a/vite/src/pipedal/PresetDialog.tsx
+++ b/vite/src/pipedal/PresetDialog.tsx
@@ -24,6 +24,7 @@ import Icon from '@mui/material/Icon';
 import Divider from '@mui/material/Divider';
 import { css } from '@emotion/react';
 import { isDarkMode } from './DarkMode';
+import { dialogActionBarBackgroundImage } from './ThemeSurfaces';
 import IconButtonEx from './IconButtonEx';
 import Typography from '@mui/material/Typography';
 import { PiPedalModel, PiPedalModelFactory, PresetIndexEntry, PresetIndex } from './PiPedalModel';
@@ -99,8 +100,8 @@ const styles = (theme: Theme) => createStyles({
     dialogActionBar: css({
         position: 'relative',
         top: 0, left: 0,
-        background: theme.palette.actionBar.main,
-        color: theme.palette.actionBar.contrastText
+        backgroundImage: dialogActionBarBackgroundImage(isDarkMode()),
+        color: '#FFFFFF',
     }),
     dialogTitle: css({
         marginLeft: theme.spacing(2),

--- a/vite/src/pipedal/PresetSelector.tsx
+++ b/vite/src/pipedal/PresetSelector.tsx
@@ -39,7 +39,6 @@ import ImportPresetFromBankDialog from './ImportPresetFromBankDialog';
 
 import Select from '@mui/material/Select';
 import UploadPresetDialog from './UploadPresetDialog';
-import { isDarkMode } from './DarkMode';
 import ResizeResponsiveComponent from './ResizeResponsiveComponent';
 
 interface PresetSelectorProps extends WithStyles<typeof styles> {
@@ -69,22 +68,25 @@ interface PresetSelectorState {
 }
 
 
-const selectColor = isDarkMode() ? "#888" : "#FFFFFF";
+const selectColor = 'currentColor';
 
 const styles = (theme: Theme) => createStyles({
-    select: { // fu fu fu.Overrides for white selector on dark background.
+    select: {
         '&:before': {
             borderColor: selectColor,
+            opacity: 0.4,
         },
         '&:after': {
             borderColor: selectColor,
         },
         '&:hover:not(.Mui-disabled):before': {
             borderColor: selectColor,
+            opacity: 0.7,
         }
     },
     icon: {
         fill: selectColor,
+        opacity: 0.7,
     },
 });
 
@@ -353,17 +355,17 @@ const PresetSelector =
                     }}>
                         <div style={{ flex: "0 0 auto" }}>
                             <IconButtonEx tooltip="Save current preset"
-                                style={{ flex: "0 0 auto", color: "#FFFFFF" }}
+                                style={{ flex: "0 0 auto" }}
                                 onClick={(e) => { this.handleSave(); }}
                                 size="large">
-                                <SaveIconOutline style={{ opacity: 0.75 }} color="inherit" />
+                                <SaveIconOutline style={{ opacity: 0.9 }} color="inherit" />
                             </IconButtonEx>
                         </div>
 
                         <div style={{ flex: "1 1 auto", minWidth: 60, maxWidth: 300, position: "relative", paddingRight: 12 }} >
                             <Select variant="standard"
                                 className={classes.select}
-                                style={{ width: "100%", position: "relative", top: 0, color: "#FFFFFF" }} disabled={!this.state.enabled}
+                                style={{ width: "100%", position: "relative", top: 0 }} disabled={!this.state.enabled}
                                 onChange={(e, extra) => this.handleChange(e, extra)}
                                 onClose={(e) => this.handleSelectClose(e)}
                                 displayEmpty
@@ -391,11 +393,11 @@ const PresetSelector =
                         <div style={{ flex: "0 0 auto" }}>
                             <IconButtonEx
                                 tooltip="More..."
-                                style={{ flex: "0 0 auto", color: "#FFFFFF" }}
+                                style={{ flex: "0 0 auto" }}
                                 onClick={(e) => this.handlePresetsMenuClick(e)}
                                 size="large"
                             >
-                                <MoreVertIcon style={{ opacity: 0.75 }} color="inherit" />
+                                <MoreVertIcon style={{ opacity: 0.9 }} color="inherit" />
                             </IconButtonEx>
                             <Menu
                                 id="edit-presets-menu"

--- a/vite/src/pipedal/SettingsDialog.tsx
+++ b/vite/src/pipedal/SettingsDialog.tsx
@@ -29,6 +29,7 @@ import Typography from '@mui/material/Typography';
 import { isDarkMode } from './DarkMode';
 import { PiPedalModel, PiPedalModelFactory, State } from './PiPedalModel';
 import { ColorTheme } from './DarkMode';
+import { ContentAlignment, getContentAlignment, setContentAlignment } from './ContentAlignment';
 import ButtonBase from "@mui/material/ButtonBase";
 import AppBar from '@mui/material/AppBar';
 import Button from '@mui/material/Button';
@@ -76,6 +77,7 @@ interface SettingsDialogProps extends WithStyles<typeof styles> {
 interface SettingsDialogState {
     showStatusMonitor: boolean;
     showStatusMonitorDialog: boolean;
+    contentAlignment: ContentAlignment;
     jackConfiguration: JackConfiguration;
     jackSettings: JackChannelSelection | null;
     channelRouterSettings: ChannelRouterSettings | null;
@@ -169,6 +171,8 @@ const styles = (theme: Theme) => createStyles({
 });
 
 
+const SETTING_ROW_MAX_WIDTH = 400;
+
 const Transition = React.forwardRef(function Transition(
     props: SlideProps, ref: React.Ref<unknown>
 ) {
@@ -192,6 +196,7 @@ const SettingsDialog = withStyles(
             this.state = {
                 showStatusMonitor: this.model.showStatusMonitor.get(),
                 showStatusMonitorDialog: false,
+                contentAlignment: getContentAlignment(),
 
                 jackServerSettings: this.model.jackServerSettings.get(),
                 channelRouterSettings: this.model.channelRouterSettings.get(),
@@ -254,6 +259,11 @@ const SettingsDialog = withStyles(
 
         handleShowStatusMonitorChanged(): void {
             this.setState({ showStatusMonitor: this.model.showStatusMonitor.get() });
+        }
+        handleContentAlignmentChanged(centered: boolean): void {
+            const value = centered ? ContentAlignment.Center : ContentAlignment.Start;
+            setContentAlignment(value);
+            this.setState({ contentAlignment: value });
         }
         handleConnectionStateChanged(): void {
             if (this.model.state.get() === State.Ready) {
@@ -907,6 +917,37 @@ const SettingsDialog = withStyles(
                                                             checked={this.state.showStatusMonitor}
                                                             onChange={
                                                                 (e) => { this.model.setShowStatusMonitor(e.target.checked); }
+                                                            }
+                                                        />
+                                                    </div>
+
+                                                </div>
+                                            </div>
+                                        </ButtonBase>
+                                        <ButtonBase
+                                            className={classes.setting}
+                                            onClick={() => {
+                                                this.handleContentAlignmentChanged(
+                                                    this.state.contentAlignment !== ContentAlignment.Center);
+                                            }}  >
+                                            <SelectHoverBackground selected={false} showHover={true} />
+                                            <div style={{ width: "100%" }}>
+                                                <div style={{
+                                                    width: "100%", display: "flex", flexDirection: "row", flexWrap: "nowrap",
+                                                    alignItems: "center", maxWidth: SETTING_ROW_MAX_WIDTH
+                                                }}>
+                                                    <div style={{ flex: "1 1 auto" }}>
+                                                        <Typography className={classes.primaryItem} display="block" variant="body2" color="textPrimary" noWrap>
+                                                            Center pedals and controls.</Typography>
+                                                        <Typography className={classes.secondaryItem} display="block" variant="caption" color="textSecondary" noWrap>
+                                                            When off, they are aligned to the left edge.</Typography>
+                                                    </div>
+
+                                                    <div style={{ flex: "0 0 auto" }}>
+                                                        <Switch
+                                                            checked={this.state.contentAlignment === ContentAlignment.Center}
+                                                            onChange={
+                                                                (e) => { this.handleContentAlignmentChanged(e.target.checked); }
                                                             }
                                                         />
                                                     </div>

--- a/vite/src/pipedal/TemporaryDrawer.tsx
+++ b/vite/src/pipedal/TemporaryDrawer.tsx
@@ -18,7 +18,7 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import React, { Component } from 'react';
-import WithStyles from './WithStyles';
+import WithStyles, { withTheme } from './WithStyles';
 import { withStyles } from "tss-react/mui";
 import {createStyles} from './WithStyles';
 
@@ -40,9 +40,10 @@ const drawerStyles = (theme: Theme) => {
 
     drawer_header: {
         color: theme.palette.primary.main,
-        background: (isDarkMode()? theme.palette.background.default: 'white'),
-
-    }
+        background: (isDarkMode()? 'linear-gradient(180deg, rgba(167,112,228,0.10) 0%, rgba(167,112,228,0) 100%)' : 'linear-gradient(180deg, rgba(103,80,164,0.08) 0%, rgba(103,80,164,0) 100%)'),
+        borderBottom: `1px solid ${isDarkMode() ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)'}`,
+        padding: '8px 4px',
+    },
 })};
 
 type Anchor = 'top' | 'left' | 'bottom' | 'right';
@@ -57,13 +58,13 @@ interface DrawerProps extends WithStyles<typeof drawerStyles> {
     is_open: boolean;
     onClose?: CloseEventHandler;
     children?: React.ReactNode;
-
+    theme: Theme;
 }
 type DrawerState = {
     is_open: boolean;
 }
 
-export const TemporaryDrawer = withStyles(
+export const TemporaryDrawer = withTheme(withStyles(
     class extends Component<DrawerProps, DrawerState>
     {
         constructor(props: DrawerProps) {
@@ -86,7 +87,7 @@ export const TemporaryDrawer = withStyles(
 
         render() {
             const classes  = withStyles.getClasses(this.props);
-
+            const theme = this.props.theme;
 
             return (
                 <div>
@@ -98,13 +99,16 @@ export const TemporaryDrawer = withStyles(
                                 onClick={() => { this.fireClose(); }}
                                 onKeyDown={() => { this.fireClose(); }}
                             >
-                                <div style={{ display: "flex", flexFlow: "row nowrap", justifyContent: "flex-start", alignItems: "center", width: "100%"}}>
+                                <div className={classes.drawer_header} style={{ display: "flex", flexFlow: "row nowrap", justifyContent: "flex-start", alignItems: "center", width: "100%", gap: 4}}>
 
                                     <IconButtonEx tooltip="Back"
-                                         style={{ flex: "0 0 auto" }} >
-                                        <ArrowBackIcon style={{ fill: '#666' }} />
+                                         style={{ flex: "0 0 auto", color: theme.palette.text.secondary }} >
+                                        <ArrowBackIcon />
                                     </IconButtonEx>
-                                    <img src="img/Pi-Logo-3.png" alt="" style={{height: 36}} />
+                                    <div style={{ flex: "1 1 auto", display: "flex", justifyContent: "center", minWidth: 0 }}>
+                                        <img src="img/Pi-Logo-3.png" alt="PiPedal" style={{height: 32, maxWidth: "100%", objectFit: "contain", filter: isDarkMode() ? 'drop-shadow(0 0 8px rgba(167,112,228,0.35))' : 'none'}} />
+                                    </div>
+                                    <div style={{ flex: "0 0 40px" }} />
                                 </div>
                                 {this.props.children}
                             </div>
@@ -115,4 +119,4 @@ export const TemporaryDrawer = withStyles(
         }
     },
     drawerStyles
-);
+));

--- a/vite/src/pipedal/ThemeSurfaces.tsx
+++ b/vite/src/pipedal/ThemeSurfaces.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Robin E.R. Davies
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy of
+// this software and associated documentation files (the "Software"), to deal in
+// the Software without restriction, including without limitation the rights to
+// use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+// the Software, and to permit persons to whom the Software is furnished to do so,
+// subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+// FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+// COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+// IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+// CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+// Surface values shared by the MUI theme and by individual dialogs, which must agree.
+
+const DARK_BAR_GRADIENT = 'linear-gradient(180deg, rgba(48,42,66,0.96) 0%, rgba(34,32,48,0.92) 100%)';
+const LIGHT_BAR_GRADIENT = 'linear-gradient(180deg, rgba(255,255,255,0.96) 0%, rgba(248,247,252,0.92) 100%)';
+const LIGHT_ACTION_BAR_GRADIENT = 'linear-gradient(180deg, rgba(103,80,164,0.96) 0%, rgba(83,64,134,0.92) 100%)';
+
+export const HAIRLINE_DARK = 'rgba(255,255,255,0.06)';
+export const HAIRLINE_LIGHT = 'rgba(0,0,0,0.06)';
+
+export const TOOLBAR_ICON_OPACITY = 0.85;
+
+export function appBarBackgroundImage(isDark: boolean): string {
+    return isDark ? DARK_BAR_GRADIENT : LIGHT_BAR_GRADIENT;
+}
+
+// Keeps white text in both themes, so it stays coloured in light mode.
+export function dialogActionBarBackgroundImage(isDark: boolean): string {
+    return isDark ? DARK_BAR_GRADIENT : LIGHT_ACTION_BAR_GRADIENT;
+}
+
+export function hairlineColor(isDark: boolean): string {
+    return isDark ? HAIRLINE_DARK : HAIRLINE_LIGHT;
+}


### PR DESCRIPTION
Frontend-only change to the Vite/React app under vite/. No C++, server, LV2 or protocol changes; no new npm dependencies; no changes outside vite/src (plus one line in vite/index.html).

Motivation
----------
Two things prompted this. First, colour values are spread across the tree: the same app-bar gradient appears in four separate files, panels stacked on a single surface each carry their own tint (which reads as horizontal banding), and a few hardcoded greys no longer match the palette they sit against. Second, the plugin browser is a flat alphabetical grid of ~450 plugins whose only navigation is scrolling or the search box; picking a known plugin by name means a long scroll.

Theme and palette
-----------------
* Collapse the duplicated light/dark component overrides in App.tsx into one sharedComponents(isDark) builder.
* Add ThemeSurfaces.tsx for values that the MUI theme and individual dialogs both use and must agree on (app-bar / action-bar gradients, hairline colour, toolbar icon opacity). Removes the gradient duplicated across App.tsx, BankDialog, PresetDialog and PluginPresetsDialog.
* Give both themes an explicit background / text / divider / action palette, and make theme.mainBackground equal palette.background.default. Those two are used interchangeably as "the app surface" (mainBackground in 13 places), so any difference shows up as banding between stacked panels.
* Take the error and reloading scrims, and the pre-React body colour in index.html, from the palette instead of hardcoded #222 / #EEE / #D0D0D0.

Incidental fixes to pre-existing defects noticed while doing the above:
* AppThemed.tsx listSubheader had backgroundImage "linear-gradient(255,255,255,0.15),rgba(255,255,255,0.15)" — missing rgba(), so the declaration was invalid and rendered nothing.
* AppThemed.tsx menuListItem set color/fill to "#FE8!important", with theme.palette.text.primary commented out beside it.

Pedalboard and controls
-----------------------
* Pedal cards get depth, an active-pedal LED, a colour strip keyed to the plugin and a dashed empty-slot treatment; connectors animate on enabled paths so the live signal path is visible.
* Respect prefers-reduced-motion: the LED stays lit and connectors stay dashed, so enabled and bypassed still look different, but both stop animating. These are the only two infinite animations in the app, and on a Pi they are also wasted power.
* New setting, Settings > Display > "Center pedals and controls", centres the pedal chain and the plugin control panel or aligns them to the start. Stored per browser in localStorage, not in server settings.

Plugin browser (LoadPluginDialog)
---------------------------------
* Chip row for the 12 top-level plugin classes. The existing dropdown stays for the ~35 nested subcategories, so nothing is lost; choosing a subcategory from the dropdown highlights its parent chip.
* A-Z jump rail. Only letters with matches are active. It is hidden while a search is active, because getFilteredPlugins then orders by match score rather than alphabetically. It resolves letters against the displayed array instead of computing offsets, since favourites are score-boosted to the top and the list is therefore not one sorted run.
* Grid/list view toggle, persisted. List rows span the full width and show the author, which is what distinguishes near-identical plugin names.
* Row restyle: plugin icons sit in tinted tiles at full opacity rather than floating at 0.6.

Toolbar
-------
* Replace the seven snapshot_N.svg glyph variants with one camera icon plus a numeric badge. NOTE: vite/src/pipedal/svg/snapshot_0..6.svg are now unused and can be deleted if you agree with the change.
* Show the "Load" label on wide screens, collapsing to icon-only below SHOW_ICON_THRESHHOLD.
* Raise monochrome toolbar icons from 0.6 to 0.85 opacity for legibility on small touch screens.
* Drop the redundant "PiPedal" text beside the drawer logo (the artwork already spells it) and centre the logo; the name moves to the img alt text.

Behaviour changes to be aware of
--------------------------------
* The new alignment setting defaults to centred, so existing users see the pedal chain and control panel centred after upgrading. Change DEFAULT_CONTENT_ALIGNMENT in ContentAlignment.tsx to ContentAlignment.Start if you would rather it be opt-in.
* Two new localStorage keys: com.twoplay.pipedal.content_alignment and com.twoplay.pipedal.load_dlg.view_mode. Both fall back to a default when absent or unparseable.

How to test
-----------
  cd vite && npm install && npm run build     # tsc -b + vite build, both clean
  npm run dev                                 # with pipedald running

1. Plugin browser: select a pedal, press Load.
   - Tap category chips; the list filters. Pick a subcategory from the dropdown on the right and confirm its parent chip highlights.
   - Click letters in the right-hand rail; the list jumps. Greyed letters have no plugins. Type in the search box and confirm the rail disappears.
   - Toggle the grid/list button in the title bar; list mode is one column with the author shown. Reopen the dialog and confirm the mode persisted.
2. Alignment: Settings > Display > "Center pedals and controls". Toggling applies immediately, with no reload. With it on, narrow the window until the chain is wider than the viewport and confirm the first pedal is still reachable (auto margins collapse rather than clipping the left edge).
3. Drag a pedal to reorder it in both alignment modes.
4. Switch Settings > Display > Color theme between Dark and Light and confirm no horizontal banding where the pedal chain, the title bar and the control panel meet.
5. Reduced motion: with the OS "reduce motion" setting on, reload and confirm the pedal LED and the connectors are static but still visibly distinguish enabled from bypassed.
6. Narrow the window below 475px and confirm the Load button collapses to an icon, then widens back to "Load".

Verified with headless Chrome against a running pipedald: switch thumbs centred (0px offset from the track in both switches), one uniform background colour down the page in both themes, 17 animating elements normally versus 0 under prefers-reduced-motion, and the A-Z rail landing on the correct row for every letter in list mode.

Not addressed: `npm run lint` does not currently run — vite/eslint.config.js has a stray `server: { proxy: ... }` block that makes ESLint abort with a ConfigError. With that removed locally, the tree reports ~2845 pre-existing errors (mostly prefer-const), so I left both the config and the errors alone rather than bury this diff. Happy to send that as its own PR. The files touched here introduce no new lint errors relative to their current state.