### PR TITLE
Fix unnamed lock_guard temporaries in AlsaSequencer

### DIFF
--- a/PiPedalCommon/src/AlsaSequencer.cpp
+++ b/PiPedalCommon/src/AlsaSequencer.cpp
@@ -91,11 +91,11 @@ namespace pipedal
 
             int myClientId = -1;
             int32_t midiChannel()  { 
-                std::lock_guard { connectionsMutex};
+                std::lock_guard lock { connectionsMutex};
                 return midiChannel_;
             }
             void midiChannel(uint32_t value) { 
-                std::lock_guard { connectionsMutex};
+                std::lock_guard lock { connectionsMutex};
                 midiChannel_ = value; 
             }
 


### PR DESCRIPTION
# Fix unnamed lock_guard temporaries in AlsaSequencer

## The symptom

A source build fails on current Raspberry Pi OS (trixie, gcc 14, aarch64):

```
AlsaSequencer.cpp:94:51: error: ignoring return value of 'std::lock_guard<_Mutex>::lock_guard(mutex_type&)',
declared with attribute 'nodiscard' [-Werror=unused-result]
```

gcc 14 marks `lock_guard`'s constructor `[[nodiscard]]`, and the project builds with `-Werror`.

## The cause

Both `midiChannel()` overloads in `AlsaSequencerImpl` construct the guard as an unnamed temporary:

```cpp
std::lock_guard { connectionsMutex};
return midiChannel_;
```

The temporary is destroyed at the end of its own statement, so the mutex is unlocked again before `midiChannel_` is touched — the accessors were effectively unsynchronized all along. The new compiler error is gcc catching a real bug rather than being pedantic.

## The change

Name the guards so they live to the end of each function. Two lines.

## Testing

Full build on Raspberry Pi OS trixie (gcc 14.2, aarch64) completes clean with `-Werror`; pipedald runs with MIDI devices configured and channel selection behaves as before. I ran into this building from source for an unrelated feature, so the fix has been in daily use on my Pi 5 since.